### PR TITLE
fix(tools): Formatting of object bodies

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -99,8 +99,11 @@ function assignBoundOperation(
 
       return {
         content: Array.isArray(response)
-          ? response.map((el) => ({ type: "text", text: String(el) }))
-          : [{ type: "text", text: String(response) }],
+          ? response.map((el) => ({
+              type: "text",
+              text: formatResponseValue(el),
+            }))
+          : [{ type: "text", text: formatResponseValue(response) }],
       };
     },
   );
@@ -146,8 +149,11 @@ function assignUnboundOperation(
 
       return {
         content: Array.isArray(response)
-          ? response.map((el) => ({ type: "text", text: String(el) }))
-          : [{ type: "text", text: String(response) }],
+          ? response.map((el) => ({
+              type: "text",
+              text: formatResponseValue(el),
+            }))
+          : [{ type: "text", text: formatResponseValue(response) }],
       };
     },
   );
@@ -168,6 +174,29 @@ function buildToolParameters(
     result[k] = determineMcpParameterType(v);
   }
   return result;
+}
+
+/**
+ * Converts a value to a string representation suitable for MCP responses
+ * Handles objects and arrays by JSON stringifying them instead of using String()
+ * @param value - The value to convert to string
+ * @returns String representation of the value
+ */
+function formatResponseValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return String(value);
+  }
+
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch (error) {
+      // Fallback to String() if JSON.stringify fails (e.g., circular references)
+      return String(value);
+    }
+  }
+
+  return String(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Fixes issue with object based return bodies on tools. 

Previously the stringification of the tool response bodies resulted in [Object,object] being the return of all MCP tools. 
The solution for this was to have a formatting function verify what type of result we were handling from the CAP service. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to bug reported directly

## What Changed

<!-- List the main changes made -->
- Formatter function implemented for MCP tools that checks if type of result from CAP is object or primitive
- Automated tests added for regression

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Create test action/function import that returns object or array of object and annotate it as a tool 
2. Call tool using debugging tool or API testing client 
3. Verify against simple primitive tools 

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [ ] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

Screenshot shows the bug that were there prior to fix:
<img width="1280" height="611" alt="mcp_tool_bug" src="https://github.com/user-attachments/assets/dd9618d0-23fc-476b-849e-ca44939dd869" />


---

