### PR TITLE
feat(auth): OAuth proxy configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@gavdi/cap-mcp",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gavdi/cap-mcp",
-      "version": "0.9.0",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "workspaces": [
         "test/demo"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.13.0",
+        "@modelcontextprotocol/sdk": "^1.17.1",
         "zod": "^3.25.67",
         "zod-to-json-schema": "^3.24.5"
       },
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
-      "integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.1.tgz",
+      "integrity": "sha512-CPle1OQehbWqd25La9Ack5B07StKIxh4+Bf19qnpZKJC1oI22Y0czZHbifjw1UoczIfKBwBDAp/dFxvHG13B5A==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
@@ -1805,6 +1805,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -2338,9 +2339,9 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.1.0.tgz",
-      "integrity": "sha512-i5bAVbFzi1uN11O4U6SdPKzYDDxc+YDSWMiqt1ryxT0WYrrehJPg5pJQjy4AH1EgRIqa3eqK2RfmHS6SgkBOyg==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.2.0.tgz",
+      "integrity": "sha512-u/R+Bzz8RsiL4JINwwmbPFmSD8Y10PGpXetGHYvUyefUG/V/S8OBAWy/elu4FmTr1X8J4+kuynCgoETaWRveKw==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
@@ -2349,7 +2350,7 @@
         "js-yaml": "^4.1.0"
       },
       "bin": {
-        "cds-deploy": "lib/dbs/cds-deploy.js",
+        "cds-deploy": "bin/deploy.js",
         "cds-serve": "bin/serve.js"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "express": "^4"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.13.0",
+    "@modelcontextprotocol/sdk": "^1.17.1",
     "zod": "^3.25.67",
     "zod-to-json-schema": "^3.24.5"
   },


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds in the OAuth proxy provider to have the MCP redirect directly to the auth provider of the CAP application. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [X] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #
- Fixes #

## What Changed

<!-- List the main changes made -->
- Added router middleware to express server (MCP Auth Router)
- Proxy to bound auth provider for the CAP application through MCP

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Step 1
2. Step 2
3. Step 3

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [X] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [X] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

