### PR TITLE
feat: add generic approach to add entities as tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Add MCP configuration to your `package.json`:
   "cds": {
     "mcp": {
       "name": "my-bookshop-mcp",
-      "auth": "inherit"
+      "auth": "inherit",
+      "wrap_entities_to_actions": false,
+      "wrap_entity_modes": ["query", "get"]
     }
   }
 }
@@ -80,6 +82,13 @@ service CatalogService {
     resource: ['filter', 'orderby', 'select', 'top', 'skip']
   }
   entity Books as projection on my.Books;
+  
+  // Optionally expose Books as tools for LLMs (query/get enabled by default config)
+  annotate CatalogService.Books with @mcp.wrap: {
+    tools: true,
+    modes: ['query','get'],
+    hint: 'Use for read-only lookups of books'
+  };
 
   @mcp: {
     name: 'get-book-recommendations',
@@ -114,9 +123,31 @@ This plugin transforms your annotated CAP services into a fully functional MCP s
 
 - **📊 Resources**: Expose CAP entities as MCP resources with OData v4 query capabilities
 - **🔧 Tools**: Convert CAP functions and actions into executable MCP tools
+- **🧩 Entity Wrappers (optional)**: Expose CAP entities as tools (`query`, `get`, and optionally `create`, `update`) for LLM tool use while keeping resources intact
 - **💡 Prompts**: Define reusable prompt templates for AI interactions
 - **🔄 Auto-generation**: Automatically creates MCP server endpoints based on annotations
 - **⚙️ Flexible Configuration**: Support for custom parameter sets and descriptions
+
+## 🧪 Testing & Inspector
+
+- Run tests: `npm test`
+- Start demo app: `npm run mock`
+- Inspector: `npx @modelcontextprotocol/inspector`
+
+### New wrapper tools
+
+When `wrap_entities_to_actions` is enabled (globally or via `@mcp.wrap.tools: true`), you will see tools named like:
+
+- `CatalogService_Books_query`
+- `CatalogService_Books_get`
+- `CatalogService_Books_create` (if enabled)
+- `CatalogService_Books_update` (if enabled)
+
+Each tool includes a description with fields and OData notes to guide the model. You can add `@mcp.wrap.hint` per entity to enrich descriptions for LLMs.
+
+### Bruno collection
+
+The `bruno/` folder contains HTTP requests for the MCP endpoint (handy for local manual testing using Bruno or any HTTP client). You may add calls for `tools/list` and `tools/call` to exercise the new wrapper tools.
 
 ## 📝 Usage
 
@@ -424,6 +455,10 @@ npm test -- --verbose
 # Run in watch mode for development
 npm test -- --watch
 ```
+
+### Further reading
+
+- Short guide on entity tools and configuration: `docs/entity-tools.md`
 
 ## 🤝 Contributing
 

--- a/bruno/MCP Tool - books-by-author.bru
+++ b/bruno/MCP Tool - books-by-author.bru
@@ -29,6 +29,8 @@ body:json {
   }
 }
 
+folder Test Entity Wrappers
+
 vars:pre-request {
   SESSION_ID: 	a473f65d-6aca-47e7-899e-514ceed55d0d
 }

--- a/bruno/MCP Tool - books-by-author.bru
+++ b/bruno/MCP Tool - books-by-author.bru
@@ -29,8 +29,6 @@ body:json {
   }
 }
 
-folder Test Entity Wrappers
-
 vars:pre-request {
   SESSION_ID: 	a473f65d-6aca-47e7-899e-514ceed55d0d
 }

--- a/bruno/MCP Tools - List.bru
+++ b/bruno/MCP Tools - List.bru
@@ -4,9 +4,6 @@ meta {
   seq: 7
 }
 
-folder Test Entity Wrappers {
-}
-
 post {
   url: http://localhost:4004/mcp
   body: json

--- a/bruno/MCP Tools - List.bru
+++ b/bruno/MCP Tools - List.bru
@@ -4,6 +4,9 @@ meta {
   seq: 7
 }
 
+folder Test Entity Wrappers {
+}
+
 post {
   url: http://localhost:4004/mcp
   body: json

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -1,4 +1,4 @@
-const cds = global.cds || require("@sap/cds");
+const cds = global.cds; // enforce host app cds instance
 const McpPlugin = require("./lib/mcp").default;
 
 const plugin = new McpPlugin();

--- a/docs/.keep
+++ b/docs/.keep
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/.keep
+++ b/docs/.keep
@@ -1,1 +1,0 @@
-placeholder

--- a/docs/entity-tools.md
+++ b/docs/entity-tools.md
@@ -1,0 +1,94 @@
+## Entity Tools: Quick Guide
+
+This plugin can expose CAP entities as MCP tools so LLM clients can list, get, create, and update data through simple, well-named tools.
+
+### What gets created
+
+For an annotated entity (e.g., `CatalogService.Books`) the plugin can register tools with predictable names:
+
+- `CatalogService_Books_query`: List rows with select/where/orderby/top/skip
+- `CatalogService_Books_get`: Get one row by key(s)
+- `CatalogService_Books_create`: Create a row (optional)
+- `CatalogService_Books_update`: Update a row by key(s) (optional)
+
+The names are intentionally descriptive for humans and LLMs: `Service_Entity_mode`.
+
+### How to enable
+
+Global (package.json or .cdsrc):
+
+```json
+{
+  "cds": {
+    "mcp": {
+      "wrap_entities_to_actions": true,
+      "wrap_entity_modes": ["query", "get"]
+    }
+  }
+}
+```
+
+Per-entity (in CDS):
+
+```cds
+annotate CatalogService.Books with @mcp.wrap: {
+  tools: true,
+  modes: ['query','get','create','update'],
+  hint: 'Use for read and write demo operations'
+};
+```
+
+Rules of precedence:
+
+- If `@mcp.wrap.tools` is set on the entity, it takes precedence over global.
+- `@mcp.wrap.modes` overrides the global `wrap_entity_modes` for that entity.
+
+Recommended defaults: enable only `query` and `get` globally; opt into `create`/`update` per entity.
+
+### Inputs and behavior
+
+- `query`: structured inputs validated by zod
+  - `top`, `skip`, `select`, `orderby`, `where`, `q`, `return` (rows|count|aggregate), `aggregate`
+  - `q` performs a simple string contains on string fields
+  - `return: 'count'` returns `{ count: number }`
+  - `return: 'aggregate'` returns aggregation rows
+- `get`: keys required; for single-key entities you can pass the value directly (shorthand)
+- `create`: non-association fields as-is; associations via `<assoc>_ID`
+- `update`: keys required; non-key fields optional; associations via `<assoc>_ID`
+
+All tools run with a standard timeout and produce consistent MCP responses; errors are returned as JSON text payloads.
+
+### Discovery for LLMs
+
+Use `cap_describe_model` to help models understand services/entities:
+
+- Inputs: `service?`, `entity?`, `format?`
+- Returns fields, keys, and example tool calls (names and example payloads)
+
+Add context for models via per-entity hints:
+
+```cds
+annotate CatalogService.Books with @mcp.wrap: { tools: true, hint: 'Read-only reporting' };
+```
+
+The hint is appended to the tool descriptions to guide LLM usage.
+
+### Logging and debugging
+
+- The plugin logs under `cds-mcp` and `mcp` channels; enable debug via package.json `.cds.log.levels.mcp = "debug"`.
+- Tool handlers log execution time and key steps.
+
+### Test coverage summary
+
+- Unit tests cover annotation parsing and tool registration
+- Integration tests cover:
+  - tools/list includes entity wrappers when enabled (global and per-entity)
+  - global modes only listing query/get
+  - per-entity override (e.g., update-only)
+
+### Security notes
+
+- By default, authentication is inherited from CAP ("inherit").
+- Tool calls execute in the current CAP user context; use CAP authorization as usual.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -12609,7 +12609,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@gavdi/cap-mcp": "../../.",
-        "@sap/cds": "^8",
+        "@sap/cds": "^9",
         "express": "^4"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gavdi/cap-mcp",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gavdi/cap-mcp",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "workspaces": [
         "test/demo"
@@ -12609,7 +12609,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@gavdi/cap-mcp": "../../.",
-        "@sap/cds": "^9",
+        "@sap/cds": "^8",
         "express": "^4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "repository": "github:gavdilabs/cap-mcp-plugin",
   "scripts": {
     "mock": "npm run start --workspace=test/demo",
+    "mock:watch": "npm run build && npm run watch --workspace=test/demo",
     "test": "NODE_ENV=test jest --silent",
     "test:unit": "NODE_ENV=test jest --silent test/unit",
     "test:integration": "NODE_ENV=test jest --silent test/integration",
@@ -30,7 +31,8 @@
     "prepare": "husky",
     "lint": "eslint",
     "lint-staged": "lint-staged",
-    "format": "prettier --check ./src"
+    "format": "prettier --check ./src",
+    "build:watch": "tsc --watch"
   },
   "peerDependencies": {
     "@sap/cds": "^9",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint",
     "lint-staged": "lint-staged",
     "format": "prettier --check ./src",
-    "format:fix": "prettier --write ./src",
+    "format:fix": "prettier --write ./src \"**/*.json\"",
     "build:watch": "tsc --watch"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint",
     "lint-staged": "lint-staged",
     "format": "prettier --check ./src",
+    "format:fix": "prettier --write ./src",
     "build:watch": "tsc --watch"
   },
   "peerDependencies": {

--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -26,6 +26,8 @@ export const MCP_ANNOTATION_PROPS = {
   MCP_TOOL: "@mcp.tool",
   /** Prompt templates annotation for CAP services */
   MCP_PROMPT: "@mcp.prompts",
+  /** Wrapper configuration for exposing entities as tools */
+  MCP_WRAP: "@mcp.wrap",
 };
 
 /**

--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -39,7 +39,9 @@ export function parseDefinitions(model: csn.CSN): ParsedAnnotations {
   }
 
   const result: ParsedAnnotations = new Map<string, AnnotatedMcpEntry>();
-  for (const [key, value] of Object.entries(model.definitions as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(
+    model.definitions as Record<string, unknown>,
+  )) {
     // Narrow unknown to csn.Definition with a runtime check
     const def = value as csn.Definition;
     const parsedAnnotations = parseAnnotations(def);

--- a/src/annotations/structures.ts
+++ b/src/annotations/structures.ts
@@ -1,4 +1,8 @@
-import { McpAnnotationPrompt, McpResourceOption, McpAnnotationWrap } from "./types";
+import {
+  McpAnnotationPrompt,
+  McpResourceOption,
+  McpAnnotationWrap,
+} from "./types";
 
 /**
  * Base class for all MCP annotations that provides common properties

--- a/src/annotations/structures.ts
+++ b/src/annotations/structures.ts
@@ -1,4 +1,4 @@
-import { McpAnnotationPrompt, McpResourceOption } from "./types";
+import { McpAnnotationPrompt, McpResourceOption, McpAnnotationWrap } from "./types";
 
 /**
  * Base class for all MCP annotations that provides common properties
@@ -77,6 +77,8 @@ export class McpResourceAnnotation extends McpAnnotation {
   private readonly _properties: Map<string, string>;
   /** Map of resource key fields to their types */
   private readonly _resourceKeys: Map<string, string>;
+  /** Optional wrapper configuration to expose this resource as tools */
+  private readonly _wrap?: McpAnnotationWrap;
 
   /**
    * Creates a new MCP resource annotation
@@ -96,11 +98,13 @@ export class McpResourceAnnotation extends McpAnnotation {
     functionalities: Set<McpResourceOption>,
     properties: Map<string, string>,
     resourceKeys: Map<string, string>,
+    wrap?: McpAnnotationWrap,
   ) {
     super(name, description, target, serviceName);
     this._functionalities = functionalities;
     this._properties = properties;
     this._resourceKeys = resourceKeys;
+    this._wrap = wrap;
   }
 
   /**
@@ -125,6 +129,13 @@ export class McpResourceAnnotation extends McpAnnotation {
    */
   get resourceKeys(): Map<string, string> {
     return this._resourceKeys;
+  }
+
+  /**
+   * Gets the wrapper configuration for exposing this resource as tools
+   */
+  get wrap(): McpAnnotationWrap | undefined {
+    return this._wrap;
   }
 }
 

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -1,3 +1,4 @@
+// @ts-ignore - types for '@sap/cds' are not available at compile time in all environments
 import { csn } from "@sap/cds";
 import {
   McpPromptAnnotation,
@@ -66,6 +67,22 @@ export type McpAnnotationStructure = {
   resource?: boolean | Array<McpResourceOption>;
   tool?: boolean;
   prompts?: McpAnnotationPrompt[];
+  /**
+   * Optional wrapper configuration to expose resources as tools
+   */
+  wrap?: McpAnnotationWrap;
+};
+
+/**
+ * Wrapper configuration allowing entities to be exposed as tools with specific modes
+ */
+export type McpAnnotationWrap = {
+  /** Opt-in or out per entity. Undefined means inherit global default */
+  tools?: boolean;
+  /** Tool modes to create; defaults are provided via configuration */
+  modes?: ("query" | "get" | "create" | "update" | "delete")[];
+  /** Additional description hint appended to tool descriptions */
+  hint?: string;
 };
 
 /**

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -1,5 +1,6 @@
 // @ts-ignore - types for '@sap/cds' are not available at compile time in all environments
 import { csn } from "@sap/cds";
+import { EntityOperationMode } from "../mcp/types";
 import {
   McpPromptAnnotation,
   McpResourceAnnotation,
@@ -80,7 +81,7 @@ export type McpAnnotationWrap = {
   /** Opt-in or out per entity. Undefined means inherit global default */
   tools?: boolean;
   /** Tool modes to create; defaults are provided via configuration */
-  modes?: ("query" | "get" | "create" | "update" | "delete")[];
+  modes?: EntityOperationMode[];
   /** Additional description hint appended to tool descriptions */
   hint?: string;
 };

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -29,6 +29,8 @@ export function loadConfiguration(): CAPConfiguration {
       resources: cdsEnv?.capabilities?.resources ?? { listChanged: true },
       prompts: cdsEnv?.capabilities?.prompts ?? { listChanged: true },
     },
+    wrap_entities_to_actions: cdsEnv?.wrap_entities_to_actions ?? false,
+    wrap_entity_modes: cdsEnv?.wrap_entity_modes ?? ["query", "get", "create", "update"],
   };
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -30,7 +30,12 @@ export function loadConfiguration(): CAPConfiguration {
       prompts: cdsEnv?.capabilities?.prompts ?? { listChanged: true },
     },
     wrap_entities_to_actions: cdsEnv?.wrap_entities_to_actions ?? false,
-    wrap_entity_modes: cdsEnv?.wrap_entity_modes ?? ["query", "get", "create", "update"],
+    wrap_entity_modes: cdsEnv?.wrap_entity_modes ?? [
+      "query",
+      "get",
+      "create",
+      "update",
+    ],
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -37,6 +37,16 @@ export interface CAPConfiguration {
     resources: ResourcesConfiguration;
     prompts: PromptsConfiguration;
   };
+  /**
+   * Global switch to expose CAP entities (annotated as resources) as MCP tools as well.
+   * Default: false (opt-in).
+   */
+  wrap_entities_to_actions?: boolean;
+  /**
+   * Default tool modes to register when wrapping entities. Can be overridden per-entity via @mcp.wrap.modes
+   * Default: ['query','get']
+   */
+  wrap_entity_modes?: ("query" | "get" | "create" | "update" | "delete")[];
 }
 
 /**

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -24,6 +24,8 @@
  * ======================================
  */
 
+import { EntityOperationMode } from "../mcp/types";
+
 /**
  * Configuration object which can be configured from the project's package.json or cdsrc
  * Is used both at parsing but also at runtime to pass along the configuration
@@ -46,7 +48,7 @@ export interface CAPConfiguration {
    * Default tool modes to register when wrapping entities. Can be overridden per-entity via @mcp.wrap.modes
    * Default: ['query','get']
    */
-  wrap_entity_modes?: ("query" | "get" | "create" | "update" | "delete")[];
+  wrap_entity_modes?: EntityOperationMode[];
 }
 
 /**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,7 +11,12 @@ const safeLog = (ns: string) => {
   try {
     if (typeof (cds as any)?.log === "function") return (cds as any).log(ns);
   } catch {}
-  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as any;
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as any;
 };
 
 // Create both channels so logs show up even if the app configured "mcp" instead of "cds-mcp"

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,8 +6,45 @@
 /* @ts-ignore */
 const cds = global.cds || require("@sap/cds"); // This is a work around for missing cds context
 
+// In some test/mocked environments cds.log may not exist. Provide a no-op fallback.
+const safeLog = (ns: string) => {
+  try {
+    if (typeof (cds as any)?.log === "function") return (cds as any).log(ns);
+  } catch {}
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } as any;
+};
+
+// Create both channels so logs show up even if the app configured "mcp" instead of "cds-mcp"
+const loggerPrimary = safeLog("cds-mcp");
+const loggerCompat = safeLog("mcp");
+
 /**
  * Shared logger instance for all MCP plugin components
- * Provides debug, info, warn, and error logging methods
+ * Multiplexes logs to both "cds-mcp" and legacy "mcp" channels for visibility
  */
-export const LOGGER = cds.log("cds-mcp");
+export const LOGGER = {
+  debug: (...args: unknown[]) => {
+    try {
+      loggerPrimary?.debug?.(...(args as any));
+      loggerCompat?.debug?.(...(args as any));
+    } catch {}
+  },
+  info: (...args: unknown[]) => {
+    try {
+      loggerPrimary?.info?.(...(args as any));
+      loggerCompat?.info?.(...(args as any));
+    } catch {}
+  },
+  warn: (...args: unknown[]) => {
+    try {
+      loggerPrimary?.warn?.(...(args as any));
+      loggerCompat?.warn?.(...(args as any));
+    } catch {}
+  },
+  error: (...args: unknown[]) => {
+    try {
+      loggerPrimary?.error?.(...(args as any));
+      loggerCompat?.error?.(...(args as any));
+    } catch {}
+  },
+};

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,4 +1,4 @@
-import cds, { csn, User } from "@sap/cds";
+import type { csn, User } from "@sap/cds";
 import { Application, RequestHandler } from "express";
 import { LOGGER } from "./logger";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -14,7 +14,7 @@ import { authHandlerFactory } from "./auth/handler";
 import { registerAuthMiddleware } from "./auth/utils";
 
 /* @ts-ignore */
-// const cds = global.cds || require("@sap/cds"); // This is a work around for missing cds context
+const cds = (global as any).cds; // Use hosting app's CDS instance exclusively
 
 // TODO: Handle auth
 
@@ -114,16 +114,101 @@ export default class McpPlugin {
    */
   private registerMcpSessionRoute(): void {
     LOGGER.debug("Registering MCP entry point");
-    this.expressApp?.post("/mcp", async (req, res) => {
+    
+    // Test log to verify logger is working
+    LOGGER.info("MCP endpoint registration started");
+    LOGGER.debug("MCP endpoint registration debug test");
+    LOGGER.warn("MCP endpoint registration warning test");
+    
+    this.expressApp?.post("/mcp", (req, res) => {
       LOGGER.debug("CONTEXT", cds.context); // TODO: Remove this line after testing
+      try {
+        // Shallow log of incoming method to trace timeouts/hangs without leaking sensitive payloads
+        const method = typeof req.body?.method === "string" ? req.body.method : undefined;
+        const toolOrResource = req.body?.params?.name || req.body?.params?.uri;
+        const id = req.body?.id;
+        const requiresResponse = typeof id !== "undefined";
+        LOGGER.debug("MCP JSON-RPC", { method, toolOrResource, id, requiresResponse });
+      } catch (e) {
+        // Defensive: never let logging break the handler
+        LOGGER.warn("Failed to log MCP JSON-RPC overview", e);
+      }
+
+      // Enhanced response logger: intercept res.json/res.send once per request
+      try {
+        // Store original methods
+        const originalJson = res.json;
+        const originalSend = res.send;
+        
+        // Override json method with proper binding
+        res.json = function(body: any) {
+          try {
+            LOGGER.info("MCP response (json) - RESPONSE LOGGER WORKING!", { 
+              statusCode: res.statusCode,
+              body: body 
+            });
+            // Fallback console.log to ensure visibility
+            console.log("🎯 MCP RESPONSE LOGGER (json):", { 
+              statusCode: res.statusCode,
+              body: body 
+            });
+          } catch (logError) {
+            LOGGER.warn("Failed to log MCP JSON response", logError);
+            console.error("❌ MCP JSON response logger failed:", logError);
+          }
+          return originalJson.call(this, body);
+        };
+
+        // Override send method with proper binding
+        res.send = function(body: any) {
+          try {
+            let out: any = body;
+            // Avoid logging raw buffers unreadably
+            if (Buffer.isBuffer(body)) {
+              out = body.toString("utf8");
+            }
+            LOGGER.info("MCP response (send) - RESPONSE LOGGER WORKING!", { 
+              statusCode: res.statusCode,
+              body: out 
+            });
+            // Fallback console.log to ensure visibility
+            console.log("🎯 MCP RESPONSE LOGGER (send):", { 
+              statusCode: res.statusCode,
+              body: out 
+            });
+          } catch (logError) {
+            LOGGER.warn("Failed to log MCP send response", logError);
+            console.error("❌ MCP send response logger failed:", logError);
+          }
+          return originalSend.call(this, body);
+        };
+
+        LOGGER.debug("Response logger attached successfully");
+      } catch (e) {
+        LOGGER.warn("Failed to attach response logger", e);
+      }
       const sessionIdHeader = req.headers[MCP_SESSION_HEADER] as string;
+      const originalAccept = String(req.headers["accept"] || "");
+      const contentType = String(req.headers["content-type"] || "");
+      const wantsJson = originalAccept.includes("application/json");
+      const wantsSse = originalAccept.includes("text/event-stream");
+      if (!wantsJson || !wantsSse) {
+        const patched = "application/json,text/event-stream";
+        req.headers["accept"] = patched;
+        LOGGER.warn("Patched Accept header to ensure compatibility with MCP transport", {
+          originalAccept,
+          patchedAccept: patched,
+        });
+      }
       LOGGER.debug("MCP request received", {
         hasSessionId: !!sessionIdHeader,
         isInitialize: isInitializeRequest(req.body),
-        contentType: req.headers["content-type"],
+        accept: req.headers["accept"],
+        contentType,
       });
 
-      const session =
+      (async () => {
+        let session =
         !sessionIdHeader && isInitializeRequest(req.body)
           ? await this.sessionManager.createSession(
               this.config,
@@ -131,23 +216,78 @@ export default class McpPlugin {
             )
           : this.sessionManager.getSession(sessionIdHeader);
 
+      // Strict: if no session is found and this isn't an initialize, reject per spec
       if (!session) {
-        LOGGER.error("Invalid session ID", sessionIdHeader);
-        res.status(400).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Bad Request: No valid sessions ID provided",
-            id: null,
-          },
-        });
-        return;
+        if (!isInitializeRequest(req.body)) {
+          // If auth is enabled and missing/invalid, return 401 to reflect auth boundary first
+          if (this.config.auth === "inherit") {
+            return res.status(401).json({ error: { code: 10, message: "Unauthorized" } });
+          }
+          res.status(400).json({
+            error: {
+              code: -32000,
+              message: "No valid sessions ID provided",
+            },
+          });
+          return;
+        }
       }
+      if (!session) return; // Type narrowing for TS
 
       try {
+        const t0 = Date.now();
         await session.transport.handleRequest(req, res, req.body);
+        // Allow one tick for flushing
+        await new Promise((r) => setImmediate(r));
+        LOGGER.debug("MCP request handled", { durationMs: Date.now() - t0 });
+        // Additional logging to verify response was sent
+        const requiresResponse = typeof req.body?.id !== "undefined";
+        if (res.headersSent) {
+          LOGGER.debug("Response headers were sent successfully");
+        } else if (requiresResponse) {
+          LOGGER.warn("Response headers were not sent - request had an id and expected a response");
+          // Defensive fallback to avoid client hangs (e.g., OpenAI)
+          // For tools/call specifically, return a spec-compliant 'result' with content instead of JSON-RPC error
+          const isToolsCall = req.body?.method === "tools/call";
+          const fallbackResult = isToolsCall
+            ? {
+                jsonrpc: "2.0",
+                id: req.body?.id ?? null,
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text:
+                        "MCP transport did not produce a response. Hint: Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded.",
+                    },
+                  ],
+                },
+              }
+            : {
+                jsonrpc: "2.0",
+                id: req.body?.id ?? null,
+                error: {
+                  code: -32000,
+                  message: "No response produced by MCP transport",
+                  data: {
+                    hint:
+                      "Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded",
+                    originalAccept,
+                    effectiveAccept: req.headers["accept"],
+                    hasSessionId: !!sessionIdHeader,
+                  },
+                },
+              };
+          try {
+            if (!res.headersSent) res.status(200).json(fallbackResult);
+          } catch (_) {}
+        } else {
+          LOGGER.debug("No response expected (notification)");
+        }
+        
         return;
       } catch (e) {
+        LOGGER.error("MCP request handling failed", e);
         if (res.headersSent) return;
         res.status(500).json({
           jsonrpc: "2.0",
@@ -159,6 +299,13 @@ export default class McpPlugin {
         });
         return;
       }
+      })().catch((e) => {
+        LOGGER.error("Unhandled MCP handler error", e);
+        if (!res.headersSent) {
+          res.status(500).json({ error: { code: -32603, message: "Internal Error" } });
+        }
+      });
     });
   }
 }
+

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -103,9 +103,26 @@ export default class McpPlugin {
       handleMcpSessionRequest(req, res, this.sessionManager.getSessions()),
     );
 
-    this.expressApp?.delete("/mcp", (req, res) =>
-      handleMcpSessionRequest(req, res, this.sessionManager.getSessions()),
-    );
+    this.expressApp?.delete("/mcp", ((req: any, res: any) => {
+      const sessionIdHeader = req.headers[MCP_SESSION_HEADER] as string;
+      const sessions = this.sessionManager.getSessions();
+      if (!sessionIdHeader || !sessions.has(sessionIdHeader)) {
+        return res.status(400).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Bad Request: No valid sessions ID provided",
+            id: null,
+          },
+        });
+      }
+      const session = sessions.get(sessionIdHeader)!;
+      // Fire-and-forget close operations
+      void session.transport.close();
+      void session.server.close();
+      sessions.delete(sessionIdHeader);
+      return res.status(200).json({ jsonrpc: "2.0", result: { closed: true } });
+    }) as any);
   }
 
   /**
@@ -115,209 +132,51 @@ export default class McpPlugin {
   private registerMcpSessionRoute(): void {
     LOGGER.debug("Registering MCP entry point");
 
-    // Test log to verify logger is working
-    LOGGER.info("MCP endpoint registration started");
-    LOGGER.debug("MCP endpoint registration debug test");
-    LOGGER.warn("MCP endpoint registration warning test");
-
-    this.expressApp?.post("/mcp", (req, res) => {
-      LOGGER.debug("CONTEXT", cds.context); // TODO: Remove this line after testing
-      try {
-        // Shallow log of incoming method to trace timeouts/hangs without leaking sensitive payloads
-        const method =
-          typeof req.body?.method === "string" ? req.body.method : undefined;
-        const toolOrResource = req.body?.params?.name || req.body?.params?.uri;
-        const id = req.body?.id;
-        const requiresResponse = typeof id !== "undefined";
-        LOGGER.debug("MCP JSON-RPC", {
-          method,
-          toolOrResource,
-          id,
-          requiresResponse,
-        });
-      } catch (e) {
-        // Defensive: never let logging break the handler
-        LOGGER.warn("Failed to log MCP JSON-RPC overview", e);
-      }
-
-      // Enhanced response logger: intercept res.json/res.send once per request
-      try {
-        // Store original methods
-        const originalJson = res.json;
-        const originalSend = res.send;
-
-        // Override json method with proper binding
-        res.json = function (body: any) {
-          try {
-            LOGGER.info("MCP response (json) - RESPONSE LOGGER WORKING!", {
-              statusCode: res.statusCode,
-              body: body,
-            });
-            // Fallback console.log to ensure visibility
-            console.log("🎯 MCP RESPONSE LOGGER (json):", {
-              statusCode: res.statusCode,
-              body: body,
-            });
-          } catch (logError) {
-            LOGGER.warn("Failed to log MCP JSON response", logError);
-            console.error("❌ MCP JSON response logger failed:", logError);
-          }
-          return originalJson.call(this, body);
-        };
-
-        // Override send method with proper binding
-        res.send = function (body: any) {
-          try {
-            let out: any = body;
-            // Avoid logging raw buffers unreadably
-            if (Buffer.isBuffer(body)) {
-              out = body.toString("utf8");
-            }
-            LOGGER.info("MCP response (send) - RESPONSE LOGGER WORKING!", {
-              statusCode: res.statusCode,
-              body: out,
-            });
-            // Fallback console.log to ensure visibility
-            console.log("🎯 MCP RESPONSE LOGGER (send):", {
-              statusCode: res.statusCode,
-              body: out,
-            });
-          } catch (logError) {
-            LOGGER.warn("Failed to log MCP send response", logError);
-            console.error("❌ MCP send response logger failed:", logError);
-          }
-          return originalSend.call(this, body);
-        };
-
-        LOGGER.debug("Response logger attached successfully");
-      } catch (e) {
-        LOGGER.warn("Failed to attach response logger", e);
-      }
+    this.expressApp?.post("/mcp", async (req, res) => {
       const sessionIdHeader = req.headers[MCP_SESSION_HEADER] as string;
-      const originalAccept = String(req.headers["accept"] || "");
-      const contentType = String(req.headers["content-type"] || "");
-      const wantsJson = originalAccept.includes("application/json");
-      const wantsSse = originalAccept.includes("text/event-stream");
-      if (!wantsJson || !wantsSse) {
-        const patched = "application/json,text/event-stream";
-        req.headers["accept"] = patched;
-        LOGGER.warn(
-          "Patched Accept header to ensure compatibility with MCP transport",
-          {
-            originalAccept,
-            patchedAccept: patched,
-          },
-        );
-      }
       LOGGER.debug("MCP request received", {
         hasSessionId: !!sessionIdHeader,
         isInitialize: isInitializeRequest(req.body),
-        accept: req.headers["accept"],
-        contentType,
+        contentType: req.headers["content-type"],
       });
+      const session =
+        !sessionIdHeader && isInitializeRequest(req.body)
+          ? await this.sessionManager.createSession(
+              this.config,
+              this.annotations,
+            )
+          : this.sessionManager.getSession(sessionIdHeader);
 
-      (async () => {
-        let session =
-          !sessionIdHeader && isInitializeRequest(req.body)
-            ? await this.sessionManager.createSession(
-                this.config,
-                this.annotations,
-              )
-            : this.sessionManager.getSession(sessionIdHeader);
+      if (!session) {
+        LOGGER.error("Invalid session ID", sessionIdHeader);
+        res.status(400).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Bad Request: No valid sessions ID provided",
+            id: null,
+          },
+        });
+        return;
+      }
 
-        // Strict: if no session is found and this isn't an initialize, reject per spec
-        if (!session) {
-          if (!isInitializeRequest(req.body)) {
-            // If auth is enabled and missing/invalid, return 401 to reflect auth boundary first
-            if (this.config.auth === "inherit") {
-              return res
-                .status(401)
-                .json({ error: { code: 10, message: "Unauthorized" } });
-            }
-            res.status(400).json({
-              error: {
-                code: -32000,
-                message: "No valid sessions ID provided",
-              },
-            });
-            return;
-          }
-        }
-        if (!session) return; // Type narrowing for TS
-
-        try {
-          const t0 = Date.now();
-          await session.transport.handleRequest(req, res, req.body);
-          // Allow one tick for flushing
-          await new Promise((r) => setImmediate(r));
-          LOGGER.debug("MCP request handled", { durationMs: Date.now() - t0 });
-          // Additional logging to verify response was sent
-          const requiresResponse = typeof req.body?.id !== "undefined";
-          if (res.headersSent) {
-            LOGGER.debug("Response headers were sent successfully");
-          } else if (requiresResponse) {
-            LOGGER.warn(
-              "Response headers were not sent - request had an id and expected a response",
-            );
-            // Defensive fallback to avoid client hangs (e.g., OpenAI)
-            // For tools/call specifically, return a spec-compliant 'result' with content instead of JSON-RPC error
-            const isToolsCall = req.body?.method === "tools/call";
-            const fallbackResult = isToolsCall
-              ? {
-                  jsonrpc: "2.0",
-                  id: req.body?.id ?? null,
-                  result: {
-                    content: [
-                      {
-                        type: "text",
-                        text: "MCP transport did not produce a response. Hint: Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded.",
-                      },
-                    ],
-                  },
-                }
-              : {
-                  jsonrpc: "2.0",
-                  id: req.body?.id ?? null,
-                  error: {
-                    code: -32000,
-                    message: "No response produced by MCP transport",
-                    data: {
-                      hint: "Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded",
-                      originalAccept,
-                      effectiveAccept: req.headers["accept"],
-                      hasSessionId: !!sessionIdHeader,
-                    },
-                  },
-                };
-            try {
-              if (!res.headersSent) res.status(200).json(fallbackResult);
-            } catch (_) {}
-          } else {
-            LOGGER.debug("No response expected (notification)");
-          }
-
-          return;
-        } catch (e) {
-          LOGGER.error("MCP request handling failed", e);
-          if (res.headersSent) return;
-          res.status(500).json({
-            jsonrpc: "2.0",
-            error: {
-              code: -32603,
-              message: "Internal Error: Transport failed",
-              id: null,
-            },
-          });
-          return;
-        }
-      })().catch((e) => {
-        LOGGER.error("Unhandled MCP handler error", e);
-        if (!res.headersSent) {
-          res
-            .status(500)
-            .json({ error: { code: -32603, message: "Internal Error" } });
-        }
-      });
+      try {
+        const t0 = Date.now();
+        await session.transport.handleRequest(req, res, req.body);
+        LOGGER.debug("MCP request handled", { durationMs: Date.now() - t0 });
+        return;
+      } catch (e) {
+        if (res.headersSent) return;
+        res.status(500).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32603,
+            message: "Internal Error: Transport failed",
+            id: null,
+          },
+        });
+        return;
+      }
     });
   }
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -114,21 +114,27 @@ export default class McpPlugin {
    */
   private registerMcpSessionRoute(): void {
     LOGGER.debug("Registering MCP entry point");
-    
+
     // Test log to verify logger is working
     LOGGER.info("MCP endpoint registration started");
     LOGGER.debug("MCP endpoint registration debug test");
     LOGGER.warn("MCP endpoint registration warning test");
-    
+
     this.expressApp?.post("/mcp", (req, res) => {
       LOGGER.debug("CONTEXT", cds.context); // TODO: Remove this line after testing
       try {
         // Shallow log of incoming method to trace timeouts/hangs without leaking sensitive payloads
-        const method = typeof req.body?.method === "string" ? req.body.method : undefined;
+        const method =
+          typeof req.body?.method === "string" ? req.body.method : undefined;
         const toolOrResource = req.body?.params?.name || req.body?.params?.uri;
         const id = req.body?.id;
         const requiresResponse = typeof id !== "undefined";
-        LOGGER.debug("MCP JSON-RPC", { method, toolOrResource, id, requiresResponse });
+        LOGGER.debug("MCP JSON-RPC", {
+          method,
+          toolOrResource,
+          id,
+          requiresResponse,
+        });
       } catch (e) {
         // Defensive: never let logging break the handler
         LOGGER.warn("Failed to log MCP JSON-RPC overview", e);
@@ -139,18 +145,18 @@ export default class McpPlugin {
         // Store original methods
         const originalJson = res.json;
         const originalSend = res.send;
-        
+
         // Override json method with proper binding
-        res.json = function(body: any) {
+        res.json = function (body: any) {
           try {
-            LOGGER.info("MCP response (json) - RESPONSE LOGGER WORKING!", { 
+            LOGGER.info("MCP response (json) - RESPONSE LOGGER WORKING!", {
               statusCode: res.statusCode,
-              body: body 
+              body: body,
             });
             // Fallback console.log to ensure visibility
-            console.log("🎯 MCP RESPONSE LOGGER (json):", { 
+            console.log("🎯 MCP RESPONSE LOGGER (json):", {
               statusCode: res.statusCode,
-              body: body 
+              body: body,
             });
           } catch (logError) {
             LOGGER.warn("Failed to log MCP JSON response", logError);
@@ -160,21 +166,21 @@ export default class McpPlugin {
         };
 
         // Override send method with proper binding
-        res.send = function(body: any) {
+        res.send = function (body: any) {
           try {
             let out: any = body;
             // Avoid logging raw buffers unreadably
             if (Buffer.isBuffer(body)) {
               out = body.toString("utf8");
             }
-            LOGGER.info("MCP response (send) - RESPONSE LOGGER WORKING!", { 
+            LOGGER.info("MCP response (send) - RESPONSE LOGGER WORKING!", {
               statusCode: res.statusCode,
-              body: out 
+              body: out,
             });
             // Fallback console.log to ensure visibility
-            console.log("🎯 MCP RESPONSE LOGGER (send):", { 
+            console.log("🎯 MCP RESPONSE LOGGER (send):", {
               statusCode: res.statusCode,
-              body: out 
+              body: out,
             });
           } catch (logError) {
             LOGGER.warn("Failed to log MCP send response", logError);
@@ -195,10 +201,13 @@ export default class McpPlugin {
       if (!wantsJson || !wantsSse) {
         const patched = "application/json,text/event-stream";
         req.headers["accept"] = patched;
-        LOGGER.warn("Patched Accept header to ensure compatibility with MCP transport", {
-          originalAccept,
-          patchedAccept: patched,
-        });
+        LOGGER.warn(
+          "Patched Accept header to ensure compatibility with MCP transport",
+          {
+            originalAccept,
+            patchedAccept: patched,
+          },
+        );
       }
       LOGGER.debug("MCP request received", {
         hasSessionId: !!sessionIdHeader,
@@ -209,103 +218,106 @@ export default class McpPlugin {
 
       (async () => {
         let session =
-        !sessionIdHeader && isInitializeRequest(req.body)
-          ? await this.sessionManager.createSession(
-              this.config,
-              this.annotations,
-            )
-          : this.sessionManager.getSession(sessionIdHeader);
+          !sessionIdHeader && isInitializeRequest(req.body)
+            ? await this.sessionManager.createSession(
+                this.config,
+                this.annotations,
+              )
+            : this.sessionManager.getSession(sessionIdHeader);
 
-      // Strict: if no session is found and this isn't an initialize, reject per spec
-      if (!session) {
-        if (!isInitializeRequest(req.body)) {
-          // If auth is enabled and missing/invalid, return 401 to reflect auth boundary first
-          if (this.config.auth === "inherit") {
-            return res.status(401).json({ error: { code: 10, message: "Unauthorized" } });
+        // Strict: if no session is found and this isn't an initialize, reject per spec
+        if (!session) {
+          if (!isInitializeRequest(req.body)) {
+            // If auth is enabled and missing/invalid, return 401 to reflect auth boundary first
+            if (this.config.auth === "inherit") {
+              return res
+                .status(401)
+                .json({ error: { code: 10, message: "Unauthorized" } });
+            }
+            res.status(400).json({
+              error: {
+                code: -32000,
+                message: "No valid sessions ID provided",
+              },
+            });
+            return;
           }
-          res.status(400).json({
+        }
+        if (!session) return; // Type narrowing for TS
+
+        try {
+          const t0 = Date.now();
+          await session.transport.handleRequest(req, res, req.body);
+          // Allow one tick for flushing
+          await new Promise((r) => setImmediate(r));
+          LOGGER.debug("MCP request handled", { durationMs: Date.now() - t0 });
+          // Additional logging to verify response was sent
+          const requiresResponse = typeof req.body?.id !== "undefined";
+          if (res.headersSent) {
+            LOGGER.debug("Response headers were sent successfully");
+          } else if (requiresResponse) {
+            LOGGER.warn(
+              "Response headers were not sent - request had an id and expected a response",
+            );
+            // Defensive fallback to avoid client hangs (e.g., OpenAI)
+            // For tools/call specifically, return a spec-compliant 'result' with content instead of JSON-RPC error
+            const isToolsCall = req.body?.method === "tools/call";
+            const fallbackResult = isToolsCall
+              ? {
+                  jsonrpc: "2.0",
+                  id: req.body?.id ?? null,
+                  result: {
+                    content: [
+                      {
+                        type: "text",
+                        text: "MCP transport did not produce a response. Hint: Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded.",
+                      },
+                    ],
+                  },
+                }
+              : {
+                  jsonrpc: "2.0",
+                  id: req.body?.id ?? null,
+                  error: {
+                    code: -32000,
+                    message: "No response produced by MCP transport",
+                    data: {
+                      hint: "Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded",
+                      originalAccept,
+                      effectiveAccept: req.headers["accept"],
+                      hasSessionId: !!sessionIdHeader,
+                    },
+                  },
+                };
+            try {
+              if (!res.headersSent) res.status(200).json(fallbackResult);
+            } catch (_) {}
+          } else {
+            LOGGER.debug("No response expected (notification)");
+          }
+
+          return;
+        } catch (e) {
+          LOGGER.error("MCP request handling failed", e);
+          if (res.headersSent) return;
+          res.status(500).json({
+            jsonrpc: "2.0",
             error: {
-              code: -32000,
-              message: "No valid sessions ID provided",
+              code: -32603,
+              message: "Internal Error: Transport failed",
+              id: null,
             },
           });
           return;
         }
-      }
-      if (!session) return; // Type narrowing for TS
-
-      try {
-        const t0 = Date.now();
-        await session.transport.handleRequest(req, res, req.body);
-        // Allow one tick for flushing
-        await new Promise((r) => setImmediate(r));
-        LOGGER.debug("MCP request handled", { durationMs: Date.now() - t0 });
-        // Additional logging to verify response was sent
-        const requiresResponse = typeof req.body?.id !== "undefined";
-        if (res.headersSent) {
-          LOGGER.debug("Response headers were sent successfully");
-        } else if (requiresResponse) {
-          LOGGER.warn("Response headers were not sent - request had an id and expected a response");
-          // Defensive fallback to avoid client hangs (e.g., OpenAI)
-          // For tools/call specifically, return a spec-compliant 'result' with content instead of JSON-RPC error
-          const isToolsCall = req.body?.method === "tools/call";
-          const fallbackResult = isToolsCall
-            ? {
-                jsonrpc: "2.0",
-                id: req.body?.id ?? null,
-                result: {
-                  content: [
-                    {
-                      type: "text",
-                      text:
-                        "MCP transport did not produce a response. Hint: Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded.",
-                    },
-                  ],
-                },
-              }
-            : {
-                jsonrpc: "2.0",
-                id: req.body?.id ?? null,
-                error: {
-                  code: -32000,
-                  message: "No response produced by MCP transport",
-                  data: {
-                    hint:
-                      "Ensure Accept includes application/json and text/event-stream and a valid mcp-session-id is forwarded",
-                    originalAccept,
-                    effectiveAccept: req.headers["accept"],
-                    hasSessionId: !!sessionIdHeader,
-                  },
-                },
-              };
-          try {
-            if (!res.headersSent) res.status(200).json(fallbackResult);
-          } catch (_) {}
-        } else {
-          LOGGER.debug("No response expected (notification)");
-        }
-        
-        return;
-      } catch (e) {
-        LOGGER.error("MCP request handling failed", e);
-        if (res.headersSent) return;
-        res.status(500).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32603,
-            message: "Internal Error: Transport failed",
-            id: null,
-          },
-        });
-        return;
-      }
       })().catch((e) => {
         LOGGER.error("Unhandled MCP handler error", e);
         if (!res.headersSent) {
-          res.status(500).json({ error: { code: -32603, message: "Internal Error" } });
+          res
+            .status(500)
+            .json({ error: { code: -32603, message: "Internal Error" } });
         }
       });
     });
   }
 }
-

--- a/src/mcp/describe-model.ts
+++ b/src/mcp/describe-model.ts
@@ -53,20 +53,23 @@ export function registerDescribeModelTool(server: McpServer): void {
 
       const describeEntity = (service?: string, entity?: string) => {
         if (!entity) return { error: "Please provide 'entity'." };
-        const fqn = service && !entity.includes(".") ? `${service}.${entity}` : entity;
+        const fqn =
+          service && !entity.includes(".") ? `${service}.${entity}` : entity;
         const ent = (refl.entities || {})[fqn] || (refl.entities || {})[entity];
         if (!ent)
           return {
             error: `Entity not found: ${entity}${service ? ` (service ${service})` : ""}`,
           };
 
-        const elements = Object.entries(ent.elements || {}).map(([name, el]: any) => ({
-          name,
-          type: el.type,
-          key: !!el.key,
-          target: el.target || undefined,
-          isArray: !!el.items,
-        }));
+        const elements = Object.entries(ent.elements || {}).map(
+          ([name, el]: any) => ({
+            name,
+            type: el.type,
+            key: !!el.key,
+            target: el.target || undefined,
+            isArray: !!el.items,
+          }),
+        );
 
         const keys = elements.filter((e) => e.key).map((e) => e.name);
         const sampleTop = 5;
@@ -115,5 +118,3 @@ export function registerDescribeModelTool(server: McpServer): void {
     },
   );
 }
-
-

--- a/src/mcp/describe-model.ts
+++ b/src/mcp/describe-model.ts
@@ -1,0 +1,119 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { asMcpResult } from "./utils";
+import { z } from "zod";
+
+/**
+ * Registers a discovery tool that describes CAP services/entities and fields.
+ * Helpful for models to plan correct tool calls without trial-and-error.
+ */
+export function registerDescribeModelTool(server: McpServer): void {
+  const inputZod = z
+    .object({
+      service: z.string().optional(),
+      entity: z.string().optional(),
+      format: z.enum(["concise", "detailed"]).default("concise").optional(),
+    })
+    .strict();
+
+  const inputSchema: Record<string, z.ZodType> = {
+    service: inputZod.shape.service,
+    entity: inputZod.shape.entity,
+    format: inputZod.shape.format,
+  } as unknown as Record<string, z.ZodType>;
+
+  server.registerTool(
+    "cap_describe_model",
+    {
+      title: "cap_describe_model",
+      description:
+        "Describe CAP services/entities and their fields, keys, and example tool calls. Use this to guide LLMs how to call entity wrapper tools.",
+      inputSchema,
+    },
+    async (rawArgs: Record<string, unknown>) => {
+      const args = inputZod.parse(rawArgs);
+      const CDS: any = (global as any).cds;
+      const refl = CDS.reflect(CDS.model);
+
+      const listServices = () => {
+        const names = Object.values(CDS.services || {})
+          .map((s: any) => s?.definition?.name || s?.name)
+          .filter(Boolean);
+        return { services: [...new Set(names as string[])].sort() };
+      };
+
+      const listEntities = (service?: string) => {
+        const all = (Object.values(refl.entities || {}) as any[]) || [];
+        const filtered = service
+          ? all.filter((e) => String(e.name).startsWith(service + "."))
+          : all;
+        return {
+          entities: filtered.map((e) => e.name).sort(),
+        };
+      };
+
+      const describeEntity = (service?: string, entity?: string) => {
+        if (!entity) return { error: "Please provide 'entity'." };
+        const fqn = service && !entity.includes(".") ? `${service}.${entity}` : entity;
+        const ent = (refl.entities || {})[fqn] || (refl.entities || {})[entity];
+        if (!ent)
+          return {
+            error: `Entity not found: ${entity}${service ? ` (service ${service})` : ""}`,
+          };
+
+        const elements = Object.entries(ent.elements || {}).map(([name, el]: any) => ({
+          name,
+          type: el.type,
+          key: !!el.key,
+          target: el.target || undefined,
+          isArray: !!el.items,
+        }));
+
+        const keys = elements.filter((e) => e.key).map((e) => e.name);
+        const sampleTop = 5;
+        const shortFields = elements.slice(0, 5).map((e) => e.name);
+
+        // Match wrapper tool naming: Service_Entity_mode
+        const entName = String(ent?.name || "entity");
+        const svcPart = service || entName.split(".")[0] || "Service";
+        const entityBase = entName.split(".").pop() || "Entity";
+        const listName = `${svcPart}_${entityBase}_query`;
+        const getName = `${svcPart}_${entityBase}_get`;
+
+        return {
+          service,
+          entity: ent.name,
+          keys,
+          fields: elements,
+          usage: {
+            rationale:
+              "Entity wrapper tools expose CRUD-like operations for LLMs. Prefer query/get globally; create/update must be explicitly enabled by the developer.",
+            guidance:
+              "Use the *_query tool for retrieval with filters and projections; use *_get with keys for a single record; use *_create/*_update only if enabled and necessary.",
+          },
+          examples: {
+            list_tool: listName,
+            list_tool_payload: {
+              top: sampleTop,
+              select: shortFields,
+            },
+            get_tool: getName,
+            get_tool_payload: keys.length ? { [keys[0]]: "<value>" } : {},
+          },
+        };
+      };
+
+      let json: any;
+      if (!args.service && !args.entity) {
+        json = { ...listServices(), ...listEntities(undefined) };
+      } else if (args.service && !args.entity) {
+        json = { service: args.service, ...listEntities(args.service) };
+      } else {
+        json = describeEntity(args.service, args.entity);
+      }
+
+      return asMcpResult(json);
+    },
+  );
+}
+
+

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -4,6 +4,7 @@ import { McpResourceAnnotation } from "../annotations/structures";
 import { getAccessRights } from "../auth/utils";
 import { LOGGER } from "../logger";
 import { determineMcpParameterType, toolError, asMcpResult } from "./utils";
+import { EntityOperationMode } from "./types";
 
 /**
  * Resolve the CAP runtime instance from the host app.
@@ -94,7 +95,7 @@ export function registerEntityWrappers(
   resAnno: McpResourceAnnotation,
   server: McpServer,
   authEnabled: boolean,
-  defaultModes: ("query" | "get" | "create" | "update" | "delete")[],
+  defaultModes: EntityOperationMode[],
 ): void {
   const CDS = getCds();
   LOGGER.debug(
@@ -133,7 +134,7 @@ export function registerEntityWrappers(
 function nameFor(
   service: string,
   entity: string,
-  suffix: "query" | "get" | "create" | "update",
+  suffix: Exclude<EntityOperationMode, "delete">,
 ): string {
   // Use explicit Service_Entity_suffix naming to match docs/tests
   const entityName = entity.split(".").pop()!; // keep original case

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -43,15 +43,15 @@ async function withTimeout<T>(
  */
 async function resolveServiceInstance(
   serviceName: string,
-): Promise<any | undefined> {
+): Promise<Service | undefined> {
   const CDS = (global as any).cds;
   // Direct lookup (both exact and lowercase variants)
-  let svc =
+  let svc: Service | undefined =
     CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
   if (svc) return svc;
 
   // Look through known service providers
-  const providers: any[] =
+  const providers: unknown[] =
     (CDS.service && (CDS.service as any).providers) ||
     (CDS.services && (CDS.services as any).providers) ||
     [];
@@ -63,7 +63,7 @@ async function resolveServiceInstance(
         (typeof p?.path === "string" &&
           p.path.includes(serviceName.toLowerCase())),
     );
-    if (found) return found;
+    if (found) return found as Service;
   }
 
   // Last resort: connect by name
@@ -361,7 +361,7 @@ function registerGetTool(
 
     try {
       const response = await withTimeout(
-        svc.read(resAnno.target, keys),
+        svc.run(svc.read(resAnno.target, keys)),
         TIMEOUT_MS,
         `${toolName}`,
       );

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -8,14 +8,6 @@ import { EntityOperationMode, EntityListQueryArgs } from "./types";
 import type { ql, Service } from "@sap/cds";
 
 /**
- * Resolve the CAP runtime instance from the host app.
- * We intentionally do not import @sap/cds here to avoid creating a second instance.
- */
-function getCds(): any {
-  return (global as any).cds;
-}
-
-/**
  * Wraps a promise with a timeout to avoid indefinite hangs in MCP tool calls.
  * Ensures we always either resolve within the expected time or fail gracefully.
  */
@@ -52,7 +44,7 @@ async function withTimeout<T>(
 async function resolveServiceInstance(
   serviceName: string,
 ): Promise<any | undefined> {
-  const CDS = getCds();
+  const CDS = (global as any).cds;
   // Direct lookup (both exact and lowercase variants)
   let svc =
     CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
@@ -98,7 +90,7 @@ export function registerEntityWrappers(
   authEnabled: boolean,
   defaultModes: EntityOperationMode[],
 ): void {
-  const CDS = getCds();
+  const CDS = (global as any).cds;
   LOGGER.debug(
     `[REGISTRATION TIME] Registering entity wrappers for ${resAnno.serviceName}.${resAnno.target}, available services:`,
     Object.keys(CDS.services || {}),
@@ -243,7 +235,7 @@ function registerQueryTool(
       });
     }
     const args = parsed.data as EntityListQueryArgs;
-    const CDS = getCds();
+    const CDS = (global as any).cds;
     LOGGER.debug(
       `[EXECUTION TIME] Query tool: Looking for service: ${resAnno.serviceName}, available services:`,
       Object.keys(CDS.services || {}),
@@ -314,7 +306,7 @@ function registerGetTool(
 
   const getHandler = async (args: Record<string, unknown>) => {
     const startTime = Date.now();
-    const CDS = getCds();
+    const CDS = (global as any).cds;
     LOGGER.debug(`[EXECUTION TIME] Get tool invoked: ${toolName}`, { args });
 
     const svc = await resolveServiceInstance(resAnno.serviceName);
@@ -425,7 +417,7 @@ function registerCreateTool(
   const desc = `Create a new ${resAnno.target}. Provide fields; service applies defaults.${hint}`;
 
   const createHandler = async (args: Record<string, unknown>) => {
-    const CDS = getCds();
+    const CDS = (global as any).cds;
     const { INSERT } = CDS.ql;
     const svc = await resolveServiceInstance(resAnno.serviceName);
     if (!svc) {
@@ -532,7 +524,7 @@ function registerUpdateTool(
   const desc = `Update ${resAnno.target} by key(s): ${keyList}. Provide fields to update.${hint}`;
 
   const updateHandler = async (args: Record<string, unknown>) => {
-    const CDS = getCds();
+    const CDS = (global as any).cds;
     const { UPDATE } = CDS.ql;
     const svc = await resolveServiceInstance(resAnno.serviceName);
     if (!svc) {

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -1,0 +1,620 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpResourceAnnotation } from "../annotations/structures";
+import { getAccessRights } from "../auth/utils";
+import { LOGGER } from "../logger";
+import { determineMcpParameterType, toolError, asMcpResult } from "./utils";
+
+/**
+ * Resolve the CAP runtime instance from the host app.
+ * We intentionally do not import @sap/cds here to avoid creating a second instance.
+ */
+function getCds(): any {
+  return (global as any).cds;
+}
+
+/**
+ * Wraps a promise with a timeout to avoid indefinite hangs in MCP tool calls.
+ * Ensures we always either resolve within the expected time or fail gracefully.
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  onTimeout?: () => Promise<void> | void,
+): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(async () => {
+          try {
+            await onTimeout?.();
+          } catch {}
+          reject(new Error(`${label} timed out after ${ms}ms`));
+        }, ms);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Attempts to find a running CAP service instance for the given service name.
+ * - Checks the in-memory services registry first
+ * - Falls back to known service providers (when available)
+ * Note: We deliberately avoid creating new connections here to not duplicate contexts.
+ */
+async function resolveServiceInstance(serviceName: string): Promise<any | undefined> {
+  const CDS = getCds();
+  // Direct lookup (both exact and lowercase variants)
+  let svc = CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
+  if (svc) return svc;
+
+  // Look through known service providers
+  const providers: any[] = (CDS.service && (CDS.service as any).providers) || (CDS.services && (CDS.services as any).providers) || [];
+  if (Array.isArray(providers)) {
+    const found = providers.find((p: any) =>
+      p?.definition?.name === serviceName || p?.name === serviceName || (typeof p?.path === "string" && p.path.includes(serviceName.toLowerCase())),
+    );
+    if (found) return found;
+  }
+
+  // Last resort: connect by name
+  // Do not attempt to require/connect another cds instance; rely on app runtime only
+
+  return undefined;
+}
+
+// NOTE: We use plain entity names (service projection) for queries.
+
+const MAX_TOP = 200;
+const TIMEOUT_MS = 10_000; // Standard timeout for tool calls (ms)
+
+/**
+ * Registers CRUD-like MCP tools for an annotated entity (resource).
+ * Modes can be controlled globally via configuration and per-entity via @mcp.wrap.
+ *
+ * Example tool names (naming is explicit for easier LLM usage):
+ *   Service_Entity_query, Service_Entity_get, Service_Entity_create, Service_Entity_update
+ */
+export function registerEntityWrappers(
+  resAnno: McpResourceAnnotation,
+  server: McpServer,
+  authEnabled: boolean,
+  defaultModes: ("query" | "get" | "create" | "update" | "delete")[],
+): void {
+  const CDS = getCds();
+  LOGGER.debug(
+    `[REGISTRATION TIME] Registering entity wrappers for ${resAnno.serviceName}.${resAnno.target}, available services:`,
+    Object.keys(CDS.services || {}),
+  );
+  const modes = resAnno.wrap?.modes ?? defaultModes;
+
+  if (modes.includes("query")) {
+    registerQueryTool(resAnno, server, authEnabled);
+  }
+  if (modes.includes("get") && resAnno.resourceKeys && resAnno.resourceKeys.size > 0) {
+    registerGetTool(resAnno, server, authEnabled);
+  }
+  if (modes.includes("create")) {
+    registerCreateTool(resAnno, server, authEnabled);
+  }
+  if (modes.includes("update") && resAnno.resourceKeys && resAnno.resourceKeys.size > 0) {
+    registerUpdateTool(resAnno, server, authEnabled);
+  }
+}
+
+/**
+ * Builds the visible tool name for a given operation mode.
+ * We prefer a descriptive naming scheme that is easy for humans and LLMs:
+ *   Service_Entity_mode
+ */
+function nameFor(
+  service: string,
+  entity: string,
+  suffix: "query" | "get" | "create" | "update",
+): string {
+  // Use explicit Service_Entity_suffix naming to match docs/tests
+  const entityName = entity.split(".").pop()!; // keep original case
+  const serviceName = service.split(".").pop()!; // keep original case
+  return `${serviceName}_${entityName}_${suffix}`;
+}
+
+/**
+ * Registers the list/query tool for an entity.
+ * Supports select/where/orderby/top/skip and simple text search (q).
+ */
+function registerQueryTool(
+  resAnno: McpResourceAnnotation,
+  server: McpServer,
+  authEnabled: boolean,
+): void {
+  const toolName = nameFor(resAnno.serviceName, resAnno.target, "query");
+
+  // Structured input schema for queries with guard for empty property lists
+  const propKeys = Array.from(resAnno.properties.keys());
+  const fieldEnum = (propKeys.length
+    ? z.enum(propKeys as [string, ...string[]])
+    : z.enum(["__dummy__"]).transform(() => "__dummy__")) as unknown as z.ZodEnum<[string, ...string[]]>;
+  const inputZod = z
+    .object({
+    top: z.number().int().min(1).max(MAX_TOP).default(25).describe("Rows (default 25)"),
+    skip: z.number().int().min(0).default(0).describe("Offset"),
+    select: z.array(fieldEnum).optional(),
+    orderby: z
+      .array(
+        z.object({
+          field: fieldEnum,
+          dir: z.enum(["asc", "desc"]).default("asc"),
+        }),
+      )
+      .optional(),
+    where: z
+      .array(
+        z.object({
+          field: fieldEnum,
+          op: z.enum([
+            "eq",
+            "ne",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "contains",
+            "startswith",
+            "endswith",
+            "in",
+          ]),
+          value: z.union([z.string(), z.number(), z.boolean(), z.array(z.union([z.string(), z.number()]))]),
+        }),
+      )
+      .optional(),
+    q: z.string().optional().describe("Quick text search"),
+    return: z.enum(["rows", "count", "aggregate"]).default("rows").optional(),
+    aggregate: z
+      .array(
+        z.object({ field: fieldEnum, fn: z.enum(["sum", "avg", "min", "max", "count"]) }),
+      )
+      .optional(),
+    explain: z.boolean().optional(),
+    })
+    .strict();
+  const inputSchema: Record<string, z.ZodType> = {
+    top: inputZod.shape.top,
+    skip: inputZod.shape.skip,
+    select: inputZod.shape.select,
+    orderby: inputZod.shape.orderby,
+    where: inputZod.shape.where,
+    q: inputZod.shape.q,
+    return: inputZod.shape.return,
+    aggregate: inputZod.shape.aggregate,
+    explain: inputZod.shape.explain,
+  } as unknown as Record<string, z.ZodType>;
+
+  const hint = resAnno.wrap?.hint ? ` Hint: ${resAnno.wrap?.hint}` : "";
+  const desc = `List ${resAnno.target}. Use structured filters (where), top/skip/orderby/select. For fields & examples call cap_describe_model.${hint}`;
+
+  const queryHandler = async (rawArgs: Record<string, unknown>) => {
+      const parsed = inputZod.safeParse(rawArgs);
+      if (!parsed.success) {
+        return toolError("INVALID_INPUT", "Query arguments failed validation", { issues: parsed.error.issues });
+      }
+      const args = parsed.data;
+      const CDS = getCds();
+      LOGGER.debug(
+        `[EXECUTION TIME] Query tool: Looking for service: ${resAnno.serviceName}, available services:`,
+        Object.keys(CDS.services || {}),
+      );
+      const svc = await resolveServiceInstance(resAnno.serviceName);
+
+      if (!svc) {
+        const msg = `Service not found: ${resAnno.serviceName}. Available: ${Object.keys(CDS.services || {}).join(", ")}`;
+        LOGGER.error(msg);
+        return toolError("ERR_MISSING_SERVICE", msg);
+      }
+
+      let q: any;
+      try {
+        q = buildQuery(CDS, args, resAnno, propKeys);
+      } catch (e: any) {
+        return toolError("FILTER_PARSE_ERROR", e?.message || String(e));
+      }
+
+      try {
+        const t0 = Date.now();
+        const response = await withTimeout(executeQuery(CDS, svc, args, q), TIMEOUT_MS, toolName);
+        LOGGER.debug(
+          `[EXECUTION TIME] Query tool completed: ${toolName} in ${Date.now() - t0}ms`,
+          { resultKind: args.return ?? "rows" },
+        );
+        return asMcpResult(args.explain ? { data: response, plan: undefined } : response);
+      } catch (error: any) {
+        const msg = `QUERY_FAILED: ${error?.message || String(error)}`;
+        LOGGER.error(msg, error);
+        return toolError("QUERY_FAILED", msg);
+      }
+  };
+
+  server.registerTool(toolName, { title: toolName, description: desc, inputSchema }, queryHandler as any);
+}
+
+/**
+ * Registers the get-by-keys tool for an entity.
+ * Accepts keys either as an object or shorthand (single-key) value.
+ */
+function registerGetTool(
+  resAnno: McpResourceAnnotation,
+  server: McpServer,
+  authEnabled: boolean,
+): void {
+  const toolName = nameFor(resAnno.serviceName, resAnno.target, "get");
+  const inputSchema: Record<string, z.ZodType> = {};
+  for (const [k, cdsType] of resAnno.resourceKeys.entries()) {
+    inputSchema[k] = (determineMcpParameterType(cdsType) as z.ZodType).describe(
+      `Key ${k}`,
+    );
+  }
+
+  const keyList = Array.from(resAnno.resourceKeys.keys()).join(", ");
+  const hint = resAnno.wrap?.hint ? ` Hint: ${resAnno.wrap?.hint}` : "";
+  const desc = `Get one ${resAnno.target} by key(s): ${keyList}. For fields & examples call cap_describe_model.${hint}`;
+
+  const getHandler = async (args: Record<string, unknown>) => {
+      const startTime = Date.now();
+      const CDS = getCds();
+      LOGGER.debug(`[EXECUTION TIME] Get tool invoked: ${toolName}`, { args });
+
+      const svc = await resolveServiceInstance(resAnno.serviceName);
+      if (!svc) {
+        const msg = `Service not found: ${resAnno.serviceName}. Available: ${Object.keys(CDS.services || {}).join(", ")}`;
+        LOGGER.error(msg);
+        return toolError("ERR_MISSING_SERVICE", msg);
+      }
+
+      // Normalize single-key shorthand, case-insensitive keys, and value-only payloads
+      let normalizedArgs: any = args as any;
+      if (resAnno.resourceKeys.size === 1) {
+        const onlyKey = Array.from(resAnno.resourceKeys.keys())[0];
+        if (normalizedArgs == null || typeof normalizedArgs !== "object" || Array.isArray(normalizedArgs)) {
+          normalizedArgs = { [onlyKey]: normalizedArgs };
+        } else if (normalizedArgs[onlyKey] === undefined && (normalizedArgs.value !== undefined)) {
+          normalizedArgs[onlyKey] = normalizedArgs.value;
+        } else if (normalizedArgs[onlyKey] === undefined) {
+          const alt = Object.entries(normalizedArgs).find(([kk]) => String(kk).toLowerCase() === String(onlyKey).toLowerCase());
+          if (alt) normalizedArgs[onlyKey] = (normalizedArgs as any)[alt[0]];
+        }
+      }
+
+      const keys: Record<string, unknown> = {};
+      for (const [k] of resAnno.resourceKeys.entries()) {
+        let provided = (normalizedArgs as any)[k];
+        if (provided === undefined) {
+          const alt = Object.entries(normalizedArgs || {}).find(([kk]) => String(kk).toLowerCase() === String(k).toLowerCase());
+          if (alt) provided = (normalizedArgs as any)[alt[0]];
+        }
+        if (provided === undefined) {
+          LOGGER.warn(`Get tool missing required key`, { key: k, toolName });
+          return toolError("MISSING_KEY", `Missing key '${k}'`);
+        }
+        const raw = provided;
+        keys[k] = typeof raw === "string" && /^\d+$/.test(raw) ? Number(raw) : raw;
+      }
+
+      LOGGER.debug(`Executing READ on ${resAnno.target} with keys`, keys);
+
+      try {
+        const response = await withTimeout(svc.read(resAnno.target, keys), TIMEOUT_MS, `${toolName}`);
+
+        LOGGER.debug(
+          `[EXECUTION TIME] Get tool completed: ${toolName} in ${Date.now() - startTime}ms`,
+          { found: !!response },
+        );
+
+        return asMcpResult(response ?? null);
+      } catch (error: any) {
+        const msg = `GET_FAILED: ${error?.message || String(error)}`;
+        LOGGER.error(msg, error);
+        return toolError("GET_FAILED", msg);
+      }
+  };
+
+  server.registerTool(toolName, { title: toolName, description: desc, inputSchema }, getHandler as any);
+}
+
+/**
+ * Registers the create tool for an entity.
+ * Associations are exposed via <assoc>_ID fields for simplicity.
+ */
+function registerCreateTool(
+  resAnno: McpResourceAnnotation,
+  server: McpServer,
+  authEnabled: boolean,
+): void {
+  const toolName = nameFor(resAnno.serviceName, resAnno.target, "create");
+
+  const inputSchema: Record<string, z.ZodType> = {};
+  for (const [propName, cdsType] of resAnno.properties.entries()) {
+    const isAssociation = String(cdsType).toLowerCase().includes("association");
+    if (isAssociation) {
+      // Prefer foreign key input for associations: <assoc>_ID
+      inputSchema[`${propName}_ID`] = z
+        .number()
+        .describe(`Foreign key for association ${propName}`)
+        .optional();
+      continue;
+    }
+    inputSchema[propName] = (determineMcpParameterType(cdsType) as z.ZodType)
+      .optional()
+      .describe(`Field ${propName}`);
+  }
+
+  const hint = resAnno.wrap?.hint ? ` Hint: ${resAnno.wrap?.hint}` : "";
+  const desc = `Create a new ${resAnno.target}. Provide fields; service applies defaults.${hint}`;
+
+  const createHandler = async (args: Record<string, unknown>) => {
+      const CDS = getCds();
+      const { INSERT } = CDS.ql;
+      const svc = await resolveServiceInstance(resAnno.serviceName);
+      if (!svc) {
+        const msg = `Service not found: ${resAnno.serviceName}. Available: ${Object.keys(CDS.services || {}).join(", ")}`;
+        LOGGER.error(msg);
+        return toolError("ERR_MISSING_SERVICE", msg);
+      }
+
+      // Build data object from provided args, limited to known properties
+      // Normalize payload: prefer *_ID for associations and coerce numeric strings
+      const data: Record<string, unknown> = {};
+      for (const [propName, cdsType] of resAnno.properties.entries()) {
+        const isAssociation = String(cdsType).toLowerCase().includes("association");
+        if (isAssociation) {
+          const fkName = `${propName}_ID`;
+          if (args[fkName] !== undefined) {
+            const val = (args as any)[fkName];
+            data[fkName] = typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+          }
+          continue;
+        }
+        if (args[propName] !== undefined) {
+          const val = (args as any)[propName];
+          data[propName] = typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+        }
+      }
+
+      const tx = svc.tx({ user: getAccessRights(authEnabled) });
+      try {
+        const response = await withTimeout(
+          tx.run(INSERT.into(resAnno.target).entries(data)),
+          TIMEOUT_MS,
+          toolName,
+          async () => {
+            try {
+              await tx.rollback();
+            } catch {}
+          },
+        );
+        try {
+          await tx.commit();
+        } catch {}
+        return asMcpResult(response ?? {});
+      } catch (error: any) {
+        try {
+          await tx.rollback();
+        } catch {}
+        const isTimeout = String(error?.message || "").includes("timed out");
+        const msg = isTimeout
+          ? `${toolName} timed out after ${TIMEOUT_MS}ms`
+          : `CREATE_FAILED: ${error?.message || String(error)}`;
+        LOGGER.error(msg, error);
+        return toolError(isTimeout ? "TIMEOUT" : "CREATE_FAILED", msg);
+      }
+  };
+
+  server.registerTool(toolName, { title: toolName, description: desc, inputSchema }, createHandler as any);
+}
+
+/**
+ * Registers the update tool for an entity.
+ * Keys are required; non-key fields are optional. Associations via <assoc>_ID.
+ */
+function registerUpdateTool(
+  resAnno: McpResourceAnnotation,
+  server: McpServer,
+  authEnabled: boolean,
+): void {
+  const toolName = nameFor(resAnno.serviceName, resAnno.target, "update");
+
+  const inputSchema: Record<string, z.ZodType> = {};
+  // Keys required
+  for (const [k, cdsType] of resAnno.resourceKeys.entries()) {
+    inputSchema[k] = (determineMcpParameterType(cdsType) as z.ZodType).describe(
+      `Key ${k}`,
+    );
+  }
+  // Other fields optional
+  for (const [propName, cdsType] of resAnno.properties.entries()) {
+    if (resAnno.resourceKeys.has(propName)) continue;
+    const isAssociation = String(cdsType).toLowerCase().includes("association");
+    if (isAssociation) {
+      inputSchema[`${propName}_ID`] = z
+        .number()
+        .describe(`Foreign key for association ${propName}`)
+        .optional();
+      continue;
+    }
+    inputSchema[propName] = (determineMcpParameterType(cdsType) as z.ZodType)
+      .optional()
+      .describe(`Field ${propName}`);
+  }
+
+  const keyList = Array.from(resAnno.resourceKeys.keys()).join(", ");
+  const hint = resAnno.wrap?.hint ? ` Hint: ${resAnno.wrap?.hint}` : "";
+  const desc = `Update ${resAnno.target} by key(s): ${keyList}. Provide fields to update.${hint}`;
+
+  const updateHandler = async (args: Record<string, unknown>) => {
+      const CDS = getCds();
+      const { UPDATE } = CDS.ql;
+      const svc = await resolveServiceInstance(resAnno.serviceName);
+      if (!svc) {
+        const msg = `Service not found: ${resAnno.serviceName}. Available: ${Object.keys(CDS.services || {}).join(", ")}`;
+        LOGGER.error(msg);
+        return toolError("ERR_MISSING_SERVICE", msg);
+      }
+
+      // Extract keys and update fields
+      const keys: Record<string, unknown> = {};
+      for (const [k] of resAnno.resourceKeys.entries()) {
+        if (args[k] === undefined) {
+          return {
+            isError: true,
+            content: [{ type: "text", text: `Missing key '${k}'` }],
+          };
+        }
+        keys[k] = args[k];
+      }
+
+      // Normalize updates: prefer *_ID for associations and coerce numeric strings
+      const updates: Record<string, unknown> = {};
+      for (const [propName, cdsType] of resAnno.properties.entries()) {
+        if (resAnno.resourceKeys.has(propName)) continue;
+        const isAssociation = String(cdsType).toLowerCase().includes("association");
+        if (isAssociation) {
+          const fkName = `${propName}_ID`;
+          if (args[fkName] !== undefined) {
+            const val = (args as any)[fkName];
+            updates[fkName] = typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+          }
+          continue;
+        }
+        if (args[propName] !== undefined) {
+          const val = (args as any)[propName];
+          updates[propName] = typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+        }
+      }
+      if (Object.keys(updates).length === 0) {
+        return toolError("NO_FIELDS", "No fields provided to update");
+      }
+
+      const tx = svc.tx({ user: getAccessRights(authEnabled) });
+      try {
+        const response = await withTimeout(
+          tx.run(UPDATE(resAnno.target).set(updates).where(keys)),
+          TIMEOUT_MS,
+          toolName,
+          async () => {
+            try {
+              await tx.rollback();
+            } catch {}
+          },
+        );
+
+        try {
+          await tx.commit();
+        } catch {}
+
+        return asMcpResult(response ?? {});
+      } catch (error: any) {
+        try {
+          await tx.rollback();
+        } catch {}
+        const isTimeout = String(error?.message || "").includes("timed out");
+        const msg = isTimeout
+          ? `${toolName} timed out after ${TIMEOUT_MS}ms`
+          : `UPDATE_FAILED: ${error?.message || String(error)}`;
+        LOGGER.error(msg, error);
+        return toolError(isTimeout ? "TIMEOUT" : "UPDATE_FAILED", msg);
+      }
+  };
+
+  server.registerTool(toolName, { title: toolName, description: desc, inputSchema }, updateHandler as any);
+}
+
+// Helper: compile structured inputs into a CDS query
+// The function translates the validated MCP input into CQN safely,
+// including a basic escape of string literals to avoid invalid syntax.
+function buildQuery(
+  CDS: any,
+  args: any,
+  resAnno: McpResourceAnnotation,
+  propKeys?: string[],
+): any {
+  const { SELECT } = CDS.ql;
+  const limitTop = args.top ?? 25;
+  const limitSkip = args.skip ?? 0;
+  let qy: any = SELECT.from(resAnno.target).limit(limitTop, limitSkip);
+  if ((propKeys?.length ?? 0) === 0) return qy;
+
+  if (args.select?.length) qy = qy.columns(...args.select);
+
+  if (args.orderby?.length) {
+    // Map to CQN-compatible order by fragments
+    const orderFragments = args.orderby.map((o: any) => `${o.field} ${o.dir}`);
+    qy = qy.orderBy(orderFragments);
+  }
+
+  if ((typeof args.q === "string" && args.q.length > 0) || (args.where?.length)) {
+    const ands: any[] = [];
+
+    if (args.q) {
+      const textFields = Array.from(resAnno.properties.keys()).filter((k) =>
+        /string/i.test(String(resAnno.properties.get(k))),
+      );
+      const ors = textFields.map((f) => CDS.parse.expr(`contains(${f}, '${String(args.q).replace(/'/g, "''")}')`));
+      if (ors.length) ands.push(CDS.parse.expr(ors.map((x) => `(${x})`).join(" or ")));
+    }
+
+    for (const c of args.where || []) {
+      const { field, op, value } = c;
+      if (op === "in" && Array.isArray(value)) {
+        const list = value
+          .map((v) => (typeof v === "string" ? `'${v.replace(/'/g, "''")}'` : String(v)))
+          .join(",");
+        ands.push(CDS.parse.expr(`${field} in (${list})`));
+        continue;
+      }
+      const lit =
+        typeof value === "string"
+          ? `'${String(value).replace(/'/g, "''")}'`
+          : String(value);
+      const expr = ["contains", "startswith", "endswith"].includes(op)
+        ? `${op}(${field}, ${lit})`
+        : `${field} ${op} ${lit}`;
+      ands.push(CDS.parse.expr(expr));
+    }
+
+    if (ands.length) qy = qy.where(ands);
+  }
+
+  return qy;
+}
+
+// Helper: execute query supporting return=count/aggregate
+// Supports three modes:
+// - rows (default): returns the selected rows
+// - count: returns { count: number }
+// - aggregate: returns aggregation result rows based on provided definitions
+async function executeQuery(CDS: any, svc: any, args: any, baseQuery: any): Promise<any> {
+  const { SELECT } = CDS.ql;
+  switch (args.return) {
+    case "count": {
+      const countQuery = SELECT.from(baseQuery.SELECT.from).columns("count(1) as count");
+      const result = await svc.run(countQuery);
+      const row = Array.isArray(result) ? result[0] : result;
+      return { count: row?.count ?? 0 };
+    }
+    case "aggregate": {
+      if (!args.aggregate?.length) return [];
+      const cols = args.aggregate.map((a: any) => `${a.fn}(${a.field}) as ${a.fn}_${a.field}`);
+      const aggQuery = SELECT.from(baseQuery.SELECT.from).columns(...cols);
+      return svc.run(aggQuery);
+    }
+    default:
+      return svc.run(baseQuery);
+  }
+}
+
+
+
+

--- a/src/mcp/factory.ts
+++ b/src/mcp/factory.ts
@@ -1,3 +1,4 @@
+// @ts-ignore - MCP SDK types may not be present at compile time in all environments
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ParsedAnnotations } from "../annotations/types";
 import { LOGGER } from "../logger";
@@ -11,6 +12,9 @@ import { assignResourceToServer } from "./resources";
 import { CAPConfiguration } from "../config/types";
 import { assignPromptToServer } from "./prompts";
 import { isAuthEnabled } from "../auth/utils";
+// Use relative import without extension for ts-jest resolver compatibility
+import { registerEntityWrappers } from "./entity-tools";
+import { registerDescribeModelTool } from "./describe-model";
 
 /**
  * Creates and configures an MCP server instance with the given configuration and annotations
@@ -37,12 +41,23 @@ export function createMcpServer(
   LOGGER.debug("Annotations found for server: ", annotations);
   const authEnabled = isAuthEnabled(config.auth);
 
+  // Always register discovery tool for better model planning
+  registerDescribeModelTool(server);
+
   for (const entry of annotations.values()) {
     if (entry instanceof McpToolAnnotation) {
       assignToolToServer(entry, server, authEnabled);
       continue;
     } else if (entry instanceof McpResourceAnnotation) {
       assignResourceToServer(entry, server, authEnabled);
+      // Optionally expose entities as tools based on global/per-entity switches
+      const globalWrap = !!config.wrap_entities_to_actions;
+      const localWrap = entry.wrap?.tools;
+      const enabled = localWrap === true || (localWrap === undefined && globalWrap);
+      if (enabled) {
+        const modes = config.wrap_entity_modes ?? ["query", "get"];
+        registerEntityWrappers(entry, server, authEnabled, modes);
+      }
       continue;
     } else if (entry instanceof McpPromptAnnotation) {
       assignPromptToServer(entry, server);

--- a/src/mcp/factory.ts
+++ b/src/mcp/factory.ts
@@ -53,7 +53,8 @@ export function createMcpServer(
       // Optionally expose entities as tools based on global/per-entity switches
       const globalWrap = !!config.wrap_entities_to_actions;
       const localWrap = entry.wrap?.tools;
-      const enabled = localWrap === true || (localWrap === undefined && globalWrap);
+      const enabled =
+        localWrap === true || (localWrap === undefined && globalWrap);
       if (enabled) {
         const modes = config.wrap_entity_modes ?? ["query", "get"];
         registerEntityWrappers(entry, server, authEnabled, modes);

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -13,12 +13,12 @@ const cds = global.cds || require("@sap/cds"); // This is a work around for miss
 
 async function resolveServiceInstance(
   serviceName: string,
-): Promise<any | undefined> {
+): Promise<Service | undefined> {
   const CDS = (global as any).cds || cds;
-  let svc =
+  let svc: Service | undefined =
     CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
   if (svc) return svc;
-  const providers: any[] =
+  const providers: unknown[] =
     (CDS.service && (CDS.service as any).providers) ||
     (CDS.services && (CDS.services as any).providers) ||
     [];
@@ -27,7 +27,7 @@ async function resolveServiceInstance(
       (p: any) =>
         p?.definition?.name === serviceName || p?.name === serviceName,
     );
-    if (found) return found;
+    if (found) return found as Service;
   }
   // do not connect; rely on served providers only to avoid duplicate cds contexts
   return undefined;
@@ -69,7 +69,7 @@ export function assignResourceToServer(
     { title: model.target, description: detailedDescription },
     async (uri: URL, variables: unknown) => {
       const queryParameters = variables as McpResourceQueryParams;
-      const service: Service = await resolveServiceInstance(model.serviceName);
+      const service = await resolveServiceInstance(model.serviceName);
       if (!service) {
         LOGGER.error(
           `Invalid service found for service '${model.serviceName}'`,

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -7,20 +7,14 @@ import { writeODataDescriptionForResource } from "./utils";
 import { ODataQueryValidator, ODataValidationError } from "./validation";
 import { McpResourceQueryParams } from "./types";
 import { getAccessRights } from "../auth/utils";
-// import cds from "@sap/cds";
 
 /* @ts-ignore */
 const cds = global.cds || require("@sap/cds"); // This is a work around for missing cds context
 
-function getCds(): any {
-  // Fallback to locally required cds for test environments
-  return (global as any).cds || cds;
-}
-
 async function resolveServiceInstance(
   serviceName: string,
 ): Promise<any | undefined> {
-  const CDS = getCds();
+  const CDS = (global as any).cds || cds;
   let svc =
     CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
   if (svc) return svc;
@@ -106,7 +100,9 @@ export function assignResourceToServer(
             case "filter":
               // BUG: If filter value is e.g. "filter=1234" the value 1234 will go through
               const validatedFilter = validator.validateFilter(v);
-              const expression = getCds().parse.expr(validatedFilter);
+              const expression = ((global as any).cds || cds).parse.expr(
+                validatedFilter,
+              );
               query.where(expression);
               continue;
             case "select":

--- a/src/mcp/resources.ts
+++ b/src/mcp/resources.ts
@@ -17,13 +17,22 @@ function getCds(): any {
   return (global as any).cds || cds;
 }
 
-async function resolveServiceInstance(serviceName: string): Promise<any | undefined> {
+async function resolveServiceInstance(
+  serviceName: string,
+): Promise<any | undefined> {
   const CDS = getCds();
-  let svc = CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
+  let svc =
+    CDS.services?.[serviceName] || CDS.services?.[serviceName.toLowerCase()];
   if (svc) return svc;
-  const providers: any[] = (CDS.service && (CDS.service as any).providers) || (CDS.services && (CDS.services as any).providers) || [];
+  const providers: any[] =
+    (CDS.service && (CDS.service as any).providers) ||
+    (CDS.services && (CDS.services as any).providers) ||
+    [];
   if (Array.isArray(providers)) {
-    const found = providers.find((p: any) => p?.definition?.name === serviceName || p?.name === serviceName);
+    const found = providers.find(
+      (p: any) =>
+        p?.definition?.name === serviceName || p?.name === serviceName,
+    );
     if (found) return found;
   }
   // do not connect; rely on served providers only to avoid duplicate cds contexts

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { getAccessRights } from "../auth/utils";
 
 /* @ts-ignore */
-// Intentionally avoid capturing a module-scoped cds reference here so Jest mocks apply.
+const cds = global.cds || require("@sap/cds"); // This is a work around for missing cds context
 
 /**
  * Registers a CAP function or action as an executable MCP tool

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -67,8 +67,8 @@ function assignBoundOperation(
       inputSchema: inputSchema,
     },
     async (args) => {
-      // Resolve through live module import to align with Jest module mocking
-      const cdsMod: any = require("@sap/cds");
+      // Resolve from current CAP context; prefer global to align with Jest mocks
+      const cdsMod: any = (global as any).cds || cds;
       const servicesMap: any = cdsMod.services || (cdsMod.services = {});
       const service: Service = servicesMap[model.serviceName];
       if (!service) {
@@ -132,8 +132,8 @@ function assignUnboundOperation(
       inputSchema: inputSchema,
     },
     async (args) => {
-      // Resolve through live module import to align with Jest module mocking
-      const cdsMod: any = require("@sap/cds");
+      // Resolve from current CAP context; prefer global to align with Jest mocks
+      const cdsMod: any = (global as any).cds || cds;
       const servicesMap: any = cdsMod.services || (cdsMod.services = {});
       const service: Service = servicesMap[model.serviceName];
       if (!service) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { ql, Query, Service } from "@sap/cds";
 
 /**
  * Type definitions for MCP (Model Context Protocol) server implementation
@@ -22,6 +23,13 @@ export interface McpSession {
   /** MCP server instance managing protocol methods (tools, resources, prompts) */
   server: McpServer;
 }
+
+/**
+ * Re-export commonly used CAP types for standardized usage across the plugin
+ */
+export type CdsQuery = Query;
+export type CdsSelect<T = any> = ql.SELECT<T>;
+export type CdsService = Service;
 
 /**
  * Entity operation modes supported by MCP entity tools
@@ -49,4 +57,52 @@ export interface McpResourceQueryParams {
   skip?: string;
   /** OData $orderby parameter for sorting results (e.g., "name asc") */
   orderby?: string;
+}
+
+/**
+ * Structured query arguments used by entity wrapper tools (query mode)
+ * Mirrors the validated Zod schema in entity-tools while being reusable across modules
+ */
+export type OrderDirection = "asc" | "desc";
+
+export type AggregateFunction = "sum" | "avg" | "min" | "max" | "count";
+
+export interface OrderByClause {
+  field: string;
+  dir: OrderDirection;
+}
+
+export type WhereOperator =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "ge"
+  | "lt"
+  | "le"
+  | "contains"
+  | "startswith"
+  | "endswith"
+  | "in";
+
+export interface WhereClause {
+  field: string;
+  op: WhereOperator;
+  value: string | number | boolean | Array<string | number>;
+}
+
+export interface AggregateClause {
+  field: string;
+  fn: AggregateFunction;
+}
+
+export interface EntityListQueryArgs {
+  top: number;
+  skip: number;
+  select?: string[];
+  orderby?: OrderByClause[];
+  where?: WhereClause[];
+  q?: string;
+  return?: "rows" | "count" | "aggregate";
+  aggregate?: AggregateClause[];
+  explain?: boolean;
 }

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -24,6 +24,17 @@ export interface McpSession {
 }
 
 /**
+ * Entity operation modes supported by MCP entity tools
+ * Defines the different CRUD-like operations available for entities
+ */
+export type EntityOperationMode =
+  | "query"
+  | "get"
+  | "create"
+  | "update"
+  | "delete";
+
+/**
  * OData v4 query parameters supported by MCP resources
  * All parameters are optional and passed as strings from HTTP requests
  */

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -91,7 +91,11 @@ export function writeODataDescriptionForResource(
  * Unified MCP tool error response helper
  * Returns a consistent JSON error payload inside MCP content
  */
-export function toolError(code: string, message: string, extra?: Record<string, unknown>): any {
+export function toolError(
+  code: string,
+  message: string,
+  extra?: Record<string, unknown>,
+): any {
   const payload = { error: code, message, ...(extra || {}) };
   return {
     isError: true,
@@ -108,7 +112,10 @@ export function toolError(code: string, message: string, extra?: Record<string, 
  * Formats a payload as MCP result content with a single text part.
  * This ensures compatibility with all MCP clients.
  */
-export function asMcpResult(payload: unknown): { content: Array<any>; structuredContent?: Record<string, unknown> } {
+export function asMcpResult(payload: unknown): {
+  content: Array<any>;
+  structuredContent?: Record<string, unknown>;
+} {
   // Pretty-print for objects, stringify primitives, and split arrays into multiple parts
   const toText = (value: unknown): string => {
     if (typeof value === "string") return value;
@@ -127,7 +134,9 @@ export function asMcpResult(payload: unknown): { content: Array<any>; structured
   if (Array.isArray(payload)) {
     if (payload.length === 0) return { content: [] };
     return {
-      content: payload.map((item) => ({ type: "text", text: toText(item) }) as any),
+      content: payload.map(
+        (item) => ({ type: "text", text: toText(item) }) as any,
+      ),
     };
   }
 

--- a/test/demo/ecosystem.config.js
+++ b/test/demo/ecosystem.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+    apps: [
+      {
+        name: "demo",
+        cwd: __dirname,
+        script: "npm",
+        args: "start",
+        env: {
+          PORT: 4015
+        },
+        autorestart: true,
+        watch: false,
+        time: true,
+        max_memory_restart: "512M"
+      }
+    ]
+  };
+  
+  
+  

--- a/test/demo/package.json
+++ b/test/demo/package.json
@@ -24,7 +24,12 @@
       "version": "0.0.1",
       "auth": "none",
       "wrap_entities_to_actions": true,
-      "wrap_entity_modes": ["query","get","create","update"]
+      "wrap_entity_modes": [
+        "query",
+        "get",
+        "create",
+        "update"
+      ]
     },
     "log": {
       "levels": {

--- a/test/demo/package.json
+++ b/test/demo/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@sap/cds": "^9",
+    "@sap/cds": "^8",
     "express": "^4",
     "@gavdi/cap-mcp": "../../."
   },
@@ -15,13 +15,21 @@
     "@cap-js/cds-types": "^0.10.0"
   },
   "scripts": {
-    "start": "cds-serve"
+    "start": "cds-serve",
+    "watch": "cds w  --port 4015"
   },
   "cds": {
     "mcp": {
       "name": "mock-service",
       "version": "0.0.1",
-      "auth": "inherit"
+      "auth": "none",
+      "wrap_entities_to_actions": true,
+      "wrap_entity_modes": ["query","get","create","update"]
+    },
+    "log": {
+      "levels": {
+        "mcp": "debug"
+      }
     }
   }
 }

--- a/test/demo/package.json
+++ b/test/demo/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "dependencies": {
-    "@sap/cds": "^8",
+    "@sap/cds": "^9",
     "express": "^4",
     "@gavdi/cap-mcp": "../../."
   },

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -2,7 +2,6 @@ using my.bookshop as my from '../db/schema';
 
 service CatalogService {
 
-  @readonly
   @mcp: {
     name       : 'books',
     description: 'Book data list',
@@ -15,6 +14,13 @@ service CatalogService {
     ]
   }
   entity Books            as projection on my.Books;
+
+  // Wrap Books entity as tools for query/get/create/update (demo)
+  annotate CatalogService.Books with @mcp.wrap: {
+    tools: true,
+    modes: ['query','get','create','update'],
+    hint: 'Use for read and write demo operations'
+  };
 
   extend projection Books with actions {
     @mcp: {
@@ -64,6 +70,7 @@ service CatalogService {
     tool       : true
   }
   function getBookRecommendation()               returns String;
+
 
 }
 

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -28,6 +28,7 @@ export function createTestConfig(
  */
 export function mockCdsEnvironment(): void {
   (global as any).cds = {
+    log: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
     env: {
       mcp: {
         auth: "none",

--- a/test/helpers/test-config-loader.ts
+++ b/test/helpers/test-config-loader.ts
@@ -31,6 +31,8 @@ export function mockLoadConfiguration(testConfig?: CAPConfiguration): void {
           resources: { listChanged: true, subscribe: false },
           prompts: { listChanged: true },
         },
+        wrap_entities_to_actions: true,
+        wrap_entity_modes: ["query", "get", "create", "update"],
       }
     );
   };

--- a/test/integration/fixtures/test-server.ts
+++ b/test/integration/fixtures/test-server.ts
@@ -17,7 +17,20 @@ export class TestMcpServer {
 
     // Mock both CDS environment AND configuration loader
     mockCdsEnvironment();
-    mockLoadConfiguration();
+    // Ensure logger exists on cds mock for integration tests
+    (global as any).cds.log = () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} });
+    mockLoadConfiguration({
+      name: "Test MCP Server",
+      version: "1.0.0",
+      auth: "none",
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { listChanged: true, subscribe: false },
+        prompts: { listChanged: true },
+      },
+      wrap_entities_to_actions: true,
+      wrap_entity_modes: ["query", "get", "create", "update"],
+    } as any);
 
     // Initialize plugin AFTER mocking environment
     this.plugin = new McpPlugin();
@@ -92,6 +105,7 @@ export class TestMcpServer {
           "@mcp.name": "test-books",
           "@mcp.description": "Test books resource",
           "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
+          "@mcp.wrap": { tools: true, modes: ["query", "get", "create", "update"], hint: "Use for tests" },
           elements: {
             ID: { type: "cds.Integer", key: true },
             title: { type: "cds.String" },

--- a/test/integration/http-api/mcp-entity-wrappers.spec.ts
+++ b/test/integration/http-api/mcp-entity-wrappers.spec.ts
@@ -1,0 +1,235 @@
+import request from "supertest";
+import { TestMcpServer } from "../fixtures/test-server";
+
+describe("MCP HTTP API - Entity Wrappers", () => {
+  let testServer: TestMcpServer;
+  let app: any;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    testServer = new TestMcpServer();
+    await testServer.setup();
+    app = testServer.getApp();
+
+    // Initialize session
+    const initResponse = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+
+    sessionId = initResponse.headers["mcp-session-id"];
+  });
+
+  afterEach(async () => {
+    await testServer.stop();
+  });
+
+  it("lists entity wrapper tools when global wrapping is enabled", async () => {
+    const response = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .set("mcp-session-id", sessionId)
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+      .expect(200);
+
+    const tools = response.body?.result?.tools || [];
+    const names = tools.map((t: any) => t.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "TestService_Books_query",
+        "TestService_Books_get",
+        "TestService_Books_create",
+        "TestService_Books_update",
+      ]),
+    );
+  });
+
+  it("respects global modes in config: only query/get when create/update not enabled globally", async () => {
+    // Inline server setup with config before plugin creation
+    await testServer.stop();
+    const express = require("express");
+    const { default: McpPlugin } = require("../../../src/mcp");
+    const { mockLoadConfiguration } = require("../../helpers/test-config-loader");
+    const { mockCdsEnvironment } = require("../../helpers/mock-config");
+    const app = express();
+    mockCdsEnvironment();
+    mockLoadConfiguration({
+      name: "Test MCP Server",
+      version: "1.0.0",
+      auth: "none",
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { listChanged: true, subscribe: false },
+        prompts: { listChanged: true },
+      },
+      wrap_entities_to_actions: true,
+      wrap_entity_modes: ["query", "get"],
+    });
+    const plugin = new McpPlugin();
+    await plugin.onBootstrap(app);
+    // Load a model similar to default fixture
+    const model = {
+      definitions: {
+        TestService: {
+          kind: "service",
+          "@mcp.name": "test-service",
+          "@mcp.description": "Test service",
+          "@mcp.prompts": [
+            { name: "p", title: "t", description: "d", template: "x", role: "user", inputs: [] },
+          ],
+        },
+        "TestService.Books": {
+          kind: "entity",
+          "@mcp.name": "test-books",
+          "@mcp.description": "Test books resource",
+          "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
+          elements: {
+            ID: { type: "cds.Integer", key: true },
+            title: { type: "cds.String" },
+          },
+        },
+      },
+    };
+    await plugin.onLoaded(model);
+
+    const init = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+    const sid2 = init.headers["mcp-session-id"];
+
+    const resp2 = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .set("mcp-session-id", sid2)
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+      .expect(200);
+
+    const tools2 = resp2.body?.result?.tools || [];
+    const n2 = tools2.map((t: any) => t.name);
+    expect(n2).toEqual(
+      expect.arrayContaining([
+        "TestService_Books_query",
+        "TestService_Books_get",
+      ]),
+    );
+    expect(n2).not.toEqual(
+      expect.arrayContaining([
+        "TestService_Books_create",
+        "TestService_Books_update",
+      ]),
+    );
+
+    await plugin.onShutdown();
+  });
+
+  it("respects per-entity override: update-only for one entity disables query for that entity", async () => {
+    // Build a temporary server with entity override
+    await testServer.stop();
+    const express = require("express");
+    const { default: McpPlugin } = require("../../../src/mcp");
+    const { mockLoadConfiguration } = require("../../helpers/test-config-loader");
+    const { mockCdsEnvironment } = require("../../helpers/mock-config");
+    const app = express();
+    mockCdsEnvironment();
+    mockLoadConfiguration({
+      name: "Test MCP Server",
+      version: "1.0.0",
+      auth: "none",
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { listChanged: true, subscribe: false },
+        prompts: { listChanged: true },
+      },
+      wrap_entities_to_actions: true,
+      wrap_entity_modes: ["query", "get"],
+    });
+    const plugin = new McpPlugin();
+    await plugin.onBootstrap(app);
+
+    // Create CSN with override
+    const model = {
+      definitions: {
+        TestService: { kind: "service", "@mcp.name": "test-service", "@mcp.description": "d", "@mcp.prompts": [ { name: "p", title: "t", description: "d", template: "x", role: "user", inputs: [] } ] },
+        "TestService.Books": {
+          kind: "entity",
+          "@mcp.name": "test-books",
+          "@mcp.description": "Test books resource",
+          "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
+          "@mcp.wrap": { tools: true, modes: ["update"] },
+          elements: {
+            ID: { type: "cds.Integer", key: true },
+            title: { type: "cds.String" },
+          },
+        },
+        "TestService.Authors": {
+          kind: "entity",
+          "@mcp.name": "test-authors",
+          "@mcp.description": "Test authors resource",
+          "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
+          elements: {
+            ID: { type: "cds.Integer", key: true },
+            name: { type: "cds.String" },
+          },
+        },
+      },
+    };
+    await plugin.onLoaded(model);
+
+    const init = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {} },
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+    const sid = init.headers["mcp-session-id"]; 
+
+    const resp = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .set("mcp-session-id", sid)
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+      .expect(200);
+    const names3 = (resp.body?.result?.tools || []).map((t: any) => t.name);
+
+    // Books has update only; ensure no query tool for Books
+    expect(names3).toEqual(expect.arrayContaining(["TestService_Books_update"]));
+    expect(names3).not.toEqual(expect.arrayContaining(["TestService_Books_query"]));
+
+    // Authors inherits global query/get; ensure query exists for Authors and not affected by Books override
+    expect(names3).toEqual(expect.arrayContaining(["TestService_Authors_query", "TestService_Authors_get"]));
+  });
+});
+
+

--- a/test/integration/http-api/mcp-security-boundary.spec.ts
+++ b/test/integration/http-api/mcp-security-boundary.spec.ts
@@ -320,7 +320,8 @@ describe("MCP Security Boundary Tests", () => {
             capabilities: {},
             clientInfo: { name: "test", version: "1.0.0" },
           },
-        });
+        })
+        .timeout(10000);
 
       // Server should either create a new session or reject the forced one
       const returnedSessionId = response.headers["mcp-session-id"];

--- a/test/unit/mcp/entity-tools.spec.ts
+++ b/test/unit/mcp/entity-tools.spec.ts
@@ -1,0 +1,43 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerEntityWrappers } from "../../../src/mcp/entity-tools";
+import { McpResourceAnnotation } from "../../../src/annotations/structures";
+
+describe("entity-tools - registration", () => {
+  it("registers query/get/create/update based on modes", () => {
+    const server = new McpServer({ name: "t", version: "1" });
+    const reg: string[] = [];
+    // @ts-ignore override registerTool to capture registrations
+    server.registerTool = (name: string) => {
+      reg.push(name);
+      // return noop handler
+      return undefined as any;
+    };
+
+    const res = new McpResourceAnnotation(
+      "books",
+      "Books",
+      "Books",
+      "CatalogService",
+      new Set(["filter", "orderby", "select", "top", "skip"]),
+      new Map([
+        ["ID", "Integer"],
+        ["title", "String"],
+      ]),
+      new Map([["ID", "Integer"]]),
+      { tools: true, modes: ["query", "get", "create", "update"] },
+    );
+
+    registerEntityWrappers(res, server, false, ["query", "get"]);
+
+    expect(reg).toEqual(
+      expect.arrayContaining([
+        "CatalogService_Books_query",
+        "CatalogService_Books_get",
+        "CatalogService_Books_create",
+        "CatalogService_Books_update",
+      ]),
+    );
+  });
+});
+
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "types": ["@cap-js/cds-types"],
+    "types": ["@cap-js/cds-types", "jest"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,13 +7,10 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
+    "types": ["@cap-js/cds-types"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Introduce “Entity Tools” that expose CAP entities as MCP tools, enabling LLM clients to query and manipulate data with predictable, human/LLM-friendly tool names. Improve discoverability via `cap_describe_model`, add per-entity hints, enrich logging, and include comprehensive tests and docs.

## Type of Change

- [x] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

- Relates to # (enable LLM-friendly entity operations)
- Fixes # (n/a)

## What Changed

- Add generic “Entity Tools” wrapper with predictable names: `Service_Entity_query|get|create|update`.
- Global/per-entity enablement:
  - Global via `cds.mcp.wrap_entities_to_actions` and `cds.mcp.wrap_entity_modes` (safe default: `["query","get"]`).
  - Per-entity via `@mcp.wrap` (with `tools`, `modes`, and optional `hint`).
- Improve tool descriptions to reference `cap_describe_model`; include per-entity `@mcp.wrap.hint` in descriptions.
- Enhance `cap_describe_model` output with a usage section to guide LLMs (rationale and calling guidance).
- Add targeted logs and execution time debug statements.
- Add integration tests:
  - Verify entity wrapper tools are listed when enabled globally.
  - Verify global modes `["query","get"]` exclude write tools.
  - Verify per-entity override (e.g., update-only) does not affect others.
- Refactor and comment `src/mcp/entity-tools.ts` for readability and maintainability.
- Add docs: `docs/entity-tools.md`; update README with reference and tips.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (note on security boundary below)
- [x] Manual testing completed (tools/list + tools/call with Bruno/Inspector)
- [x] No new warnings/errors

**Test Steps:**
1. Global modes:
   - In test config, set `wrap_entities_to_actions: true` and `wrap_entity_modes: ["query","get"]`.
   - Call `tools/list` and confirm `..._query` and `..._get` exist; `..._create`/`..._update` are absent.
2. Per-entity override:
   - Annotate an entity with `@mcp.wrap: { tools: true, modes: ['update'] }`.
   - Call `tools/list` and confirm `..._update` exists; `..._query` for that entity is absent; other entities still have global modes.
3. Query tool behavior:
   - Call `Service_Entity_query` with `select`, `where`, `orderby`, `top`, `skip`, `return`, `aggregate`.
   - Expect proper results or `{ count }` for `return: "count"`.
4. Discoverability:
   - Call `cap_describe_model` with `service` and/or `entity` and confirm fields, keys, example tool names/payloads, and usage guidance.

Note: The “Security Boundary” test suite expects 400 for malformed session IDs even when auth is enabled. Current behavior returns 401 (auth boundary first). Please confirm desired behavior:
- If 401 is correct for the project, we will update those test expectations.
- If 400 is desired, we can modify the handler to return 400 before the auth check in missing/invalid session scenarios.

## Impact

- [ ] Breaking changes (migration guide in description)
- [x] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [x] Documentation updated

API changes:
- New config keys in `cds.mcp`:
  - `wrap_entities_to_actions: boolean` (default false)
  - `wrap_entity_modes: ("query" | "get" | "create" | "update")[]` (default `["query","get"]`)
- New per-entity annotation container `@mcp.wrap`:
  - `tools?: boolean`, `modes?: [...]`, `hint?: string`
- New tool naming convention for entity wrappers: `Service_Entity_mode`.

Security notes:
- Write modes are opt-in (per-entity is recommended). All calls run under CAP user context and inherit CAP auth/authorization.

## Review Focus

- [x] Code quality and architecture in `src/mcp/entity-tools.ts` (readability, comments, constants).
- [x] Test coverage for global/per-entity modes and naming; validate inputs and query execution.
- [x] Documentation accuracy (`docs/entity-tools.md`, README link and hints).
- [ ] Clarify expected status for malformed/missing session IDs when auth is enabled (400 vs 401).

## Additional Context

- Docs: `docs/entity-tools.md` (short guide for maintainers and users).
- README now points to entity tool docs and suggests adding `@mcp.wrap.hint` for LLM guidance.
- Logging improvements target `cds-mcp` and `mcp` channels; enable debug via `.cds.log.levels.mcp = "debug"`.