### PR TITLE
feat: add delete to entity tools

### DIFF
--- a/docs/entity-tools.md
+++ b/docs/entity-tools.md
@@ -10,6 +10,7 @@ For an annotated entity (e.g., `CatalogService.Books`) the plugin can register t
 - `CatalogService_Books_get`: Get one row by key(s)
 - `CatalogService_Books_create`: Create a row (optional)
 - `CatalogService_Books_update`: Update a row by key(s) (optional)
+- `CatalogService_Books_delete`: Delete a row by key(s) (optional)
 
 The names are intentionally descriptive for humans and LLMs: `Service_Entity_mode`.
 
@@ -33,7 +34,7 @@ Per-entity (in CDS):
 ```cds
 annotate CatalogService.Books with @mcp.wrap: {
   tools: true,
-  modes: ['query','get','create','update'],
+  modes: ['query','get','create','update','delete'],
   hint: 'Use for read and write demo operations'
 };
 ```
@@ -43,7 +44,7 @@ Rules of precedence:
 - If `@mcp.wrap.tools` is set on the entity, it takes precedence over global.
 - `@mcp.wrap.modes` overrides the global `wrap_entity_modes` for that entity.
 
-Recommended defaults: enable only `query` and `get` globally; opt into `create`/`update` per entity.
+Recommended defaults: enable only `query` and `get` globally; opt into `create`/`update`/`delete` per entity.
 
 ### Inputs and behavior
 
@@ -55,6 +56,7 @@ Recommended defaults: enable only `query` and `get` globally; opt into `create`/
 - `get`: keys required; for single-key entities you can pass the value directly (shorthand)
 - `create`: non-association fields as-is; associations via `<assoc>_ID`
 - `update`: keys required; non-key fields optional; associations via `<assoc>_ID`
+- `delete`: keys required; this operation cannot be undone
 
 All tools run with a standard timeout and produce consistent MCP responses; errors are returned as JSON text payloads.
 

--- a/test/integration/fixtures/test-server.ts
+++ b/test/integration/fixtures/test-server.ts
@@ -18,7 +18,12 @@ export class TestMcpServer {
     // Mock both CDS environment AND configuration loader
     mockCdsEnvironment();
     // Ensure logger exists on cds mock for integration tests
-    (global as any).cds.log = () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} });
+    (global as any).cds.log = () => ({
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    });
     mockLoadConfiguration({
       name: "Test MCP Server",
       version: "1.0.0",
@@ -29,7 +34,7 @@ export class TestMcpServer {
         prompts: { listChanged: true },
       },
       wrap_entities_to_actions: true,
-      wrap_entity_modes: ["query", "get", "create", "update"],
+      wrap_entity_modes: ["query", "get", "create", "update", "delete"],
     } as any);
 
     // Initialize plugin AFTER mocking environment
@@ -105,7 +110,11 @@ export class TestMcpServer {
           "@mcp.name": "test-books",
           "@mcp.description": "Test books resource",
           "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
-          "@mcp.wrap": { tools: true, modes: ["query", "get", "create", "update"], hint: "Use for tests" },
+          "@mcp.wrap": {
+            tools: true,
+            modes: ["query", "get", "create", "update", "delete"],
+            hint: "Use for tests",
+          },
           elements: {
             ID: { type: "cds.Integer", key: true },
             title: { type: "cds.String" },

--- a/test/unit/mcp/entity-tools.spec.ts
+++ b/test/unit/mcp/entity-tools.spec.ts
@@ -3,7 +3,7 @@ import { registerEntityWrappers } from "../../../src/mcp/entity-tools";
 import { McpResourceAnnotation } from "../../../src/annotations/structures";
 
 describe("entity-tools - registration", () => {
-  it("registers query/get/create/update based on modes", () => {
+  it("registers query/get/create/update/delete based on modes", () => {
     const server = new McpServer({ name: "t", version: "1" });
     const reg: string[] = [];
     // @ts-ignore override registerTool to capture registrations
@@ -24,7 +24,7 @@ describe("entity-tools - registration", () => {
         ["title", "String"],
       ]),
       new Map([["ID", "Integer"]]),
-      { tools: true, modes: ["query", "get", "create", "update"] },
+      { tools: true, modes: ["query", "get", "create", "update", "delete"] },
     );
 
     registerEntityWrappers(res, server, false, ["query", "get"]);
@@ -35,9 +35,66 @@ describe("entity-tools - registration", () => {
         "CatalogService_Books_get",
         "CatalogService_Books_create",
         "CatalogService_Books_update",
+        "CatalogService_Books_delete",
       ]),
     );
   });
+
+  it("registers only delete when delete mode is specified", () => {
+    const server = new McpServer({ name: "t", version: "1" });
+    const reg: string[] = [];
+    // @ts-ignore override registerTool to capture registrations
+    server.registerTool = (name: string) => {
+      reg.push(name);
+      // return noop handler
+      return undefined as any;
+    };
+
+    const res = new McpResourceAnnotation(
+      "books",
+      "Books",
+      "Books",
+      "CatalogService",
+      new Set(["filter", "orderby", "select", "top", "skip"]),
+      new Map([
+        ["ID", "Integer"],
+        ["title", "String"],
+      ]),
+      new Map([["ID", "Integer"]]),
+      { tools: true, modes: ["delete"] },
+    );
+
+    registerEntityWrappers(res, server, false, []);
+
+    expect(reg).toEqual(["CatalogService_Books_delete"]);
+  });
+
+  it("does not register delete for entities without keys", () => {
+    const server = new McpServer({ name: "t", version: "1" });
+    const reg: string[] = [];
+    // @ts-ignore override registerTool to capture registrations
+    server.registerTool = (name: string) => {
+      reg.push(name);
+      // return noop handler
+      return undefined as any;
+    };
+
+    const res = new McpResourceAnnotation(
+      "books",
+      "Books",
+      "Books",
+      "CatalogService",
+      new Set(["filter", "orderby", "select", "top", "skip"]),
+      new Map([
+        ["ID", "Integer"],
+        ["title", "String"],
+      ]),
+      new Map([]), // No keys - delete should not be registered
+      { tools: true, modes: ["delete"] },
+    );
+
+    registerEntityWrappers(res, server, false, []);
+
+    expect(reg).toEqual([]);
+  });
 });
-
-


### PR DESCRIPTION
## Summary

Add delete functionality to CAP MCP Plugin entity-tools feature, enabling LLMs to perform DELETE operations on CAP entities through MCP tools. This completes the CRUD operations suite (Create, Read, Update, Delete) for entity wrappers.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [x] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to entity-tools feature completion
- Addresses user request for full CRUD operations

## What Changed

- **Added `registerDeleteTool` function** in `src/mcp/entity-tools.ts` following existing patterns
- **Updated `nameFor` function** to support delete operation (removed exclusion)  
- **Enhanced `registerEntityWrappers`** to register delete tools when `"delete"` mode is specified
- **Updated documentation** in `docs/entity-tools.md` with delete operation examples and usage
- **Expanded unit tests** in `test/unit/mcp/entity-tools.spec.ts` with delete-specific test cases
- **Enhanced integration tests** in `test/integration/http-api/mcp-entity-wrappers.spec.ts` for delete tool validation
- **Updated test fixtures** to include delete mode in entity annotations and global configuration

## Testing

<!-- Mark completed testing with "x" -->
- [x] Unit tests pass
- [x] Integration tests pass  
- [x] Manual testing completed
- [x] No new warnings/errors

**Test Steps:**
1. Run `npm test -- --testPathPattern=entity-tools.spec.ts` - All unit tests pass (3/3)
2. Run `npm test -- --testPathPattern=mcp-entity-wrappers.spec.ts` - All integration tests pass (4/4)
3. Run full test suite `npm test` - All 408 tests pass across 28 test suites
4. Verify delete tools are registered with proper schema and description containing warning text

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [x] Documentation updated

**API Changes:**
- **New tool naming**: `Service_Entity_delete` (e.g., `CatalogService_Books_delete`)
- **New mode option**: `"delete"` can be added to `wrap_entity_modes` array and `@mcp.wrap.modes`
- **Tool behavior**: Requires entity keys, returns `{deleted: true}` on success, includes warning "cannot be undone"

## Review Focus

<!-- Help reviewers know what to focus on -->
- [x] Code quality and architecture
- [x] Test coverage and quality
- [x] Performance and security
- [x] Documentation accuracy
- [ ] Breaking change handling

**Key Review Areas:**
- **Transaction safety**: Delete operations use proper transaction handling with rollback on errors
- **Timeout protection**: 10-second timeout prevents hanging operations  
- **Key validation**: Case-insensitive key matching and numeric coercion like other operations
- **Error handling**: Comprehensive error responses with specific error codes
- **Security**: Inherits same authentication patterns as other CRUD operations

## Additional Context

**Implementation follows established patterns:**
- Same transaction and timeout handling as create/update operations
- Consistent key processing logic as get/update operations  
- Proper MCP error response formatting
- Authentication integration using `getAccessRights()`

**Tool registration requirements:**
- Only registers delete tools for entities with defined `resourceKeys` (like get/update)
- Respects both global `wrap_entity_modes` and per-entity `@mcp.wrap.modes` configuration
- Follows explicit opt-in approach - delete mode must be explicitly enabled

**Usage example:**
```cds
annotate CatalogService.Books with @mcp.wrap: {
  tools: true,
  modes: ['query','get','create','update','delete'],
  hint: 'Full CRUD operations available'
};
```

Generates tool: `CatalogService_Books_delete` with required keys input schema.

---