### PR TITLE
feat: add server instructions to MCP server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Add MCP configuration to your `package.json`:
       "name": "my-bookshop-mcp",
       "auth": "inherit",
       "wrap_entities_to_actions": false,
-      "wrap_entity_modes": ["query", "get"]
+      "wrap_entity_modes": ["query", "get"],
+      "instructions": "MCP server instructions for agents"
     }
   }
 }
@@ -251,6 +252,7 @@ Configure the MCP plugin through your CAP application's `package.json` or `.cdsr
       "name": "my-mcp-server",
       "version": "1.0.0",
       "auth": "inherit",
+      "instructions": "mcp server instructions for agents",
       "capabilities": {
         "resources": {
           "listChanged": true,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -36,6 +36,7 @@ export function loadConfiguration(): CAPConfiguration {
       "create",
       "update",
     ],
+    instructions: cdsEnv?.instructions,
   };
 }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,10 @@ export interface CAPConfiguration {
    * Default: ['query','get']
    */
   wrap_entity_modes?: EntityOperationMode[];
+  /**
+   * Instructions for the MCP server
+   */
+  instructions?: string;
 }
 
 /**

--- a/src/mcp/factory.ts
+++ b/src/mcp/factory.ts
@@ -27,11 +27,14 @@ export function createMcpServer(
   annotations?: ParsedAnnotations,
 ): McpServer {
   LOGGER.debug("Creating MCP server instance");
-  const server = new McpServer({
-    name: config.name,
-    version: config.version,
-    capabilities: config.capabilities,
-  });
+  const server = new McpServer(
+    {
+      name: config.name,
+      version: config.version,
+      capabilities: config.capabilities,
+    },
+    { instructions: config.instructions },
+  );
 
   if (!annotations) {
     LOGGER.debug("No annotations provided, skipping registration...");

--- a/test/demo/package.json
+++ b/test/demo/package.json
@@ -23,6 +23,7 @@
       "name": "mock-service",
       "version": "0.0.1",
       "auth": "none",
+      "instructions": "Use this server to query books",
       "wrap_entities_to_actions": true,
       "wrap_entity_modes": [
         "query",

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -19,6 +19,7 @@ export function createTestConfig(
       resources: { listChanged: true, subscribe: false },
       prompts: { listChanged: true },
     },
+    instructions: "Use this server to test the MCP server implementation",
     ...overrides,
   };
 }
@@ -28,7 +29,12 @@ export function createTestConfig(
  */
 export function mockCdsEnvironment(): void {
   (global as any).cds = {
-    log: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+    log: () => ({
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    }),
     env: {
       mcp: {
         auth: "none",

--- a/test/unit/mcp/factory.spec.ts
+++ b/test/unit/mcp/factory.spec.ts
@@ -73,11 +73,14 @@ describe("Factory", () => {
     test("should create server without annotations", () => {
       const server = createMcpServer(mockConfig);
 
-      expect(McpServer).toHaveBeenCalledWith({
-        name: "Test Server",
-        version: "1.0.0",
-        capabilities: mockConfig.capabilities,
-      });
+      expect(McpServer).toHaveBeenCalledWith(
+        {
+          name: "Test Server",
+          version: "1.0.0",
+          capabilities: mockConfig.capabilities,
+        },
+        { instructions: mockConfig.instructions },
+      );
       expect(server).toBeDefined();
       expect(LOGGER.debug).toHaveBeenCalledWith("Creating MCP server instance");
     });


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
This PR adds the possibility to add server instructions as described in the model context provider protocol specification
https://github.com/modelcontextprotocol/typescript-sdk/blob/4a63974049e27efb3c99325b29454127eed33adf/src/server/index.ts#L47

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [X] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #
- Fixes #

## What Changed

<!-- List the main changes made -->
- Additional configuration option "instructions" in the CDS MCP configuration
- Demo sample updated
- Test updated

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Add new instructions configuration option in the MCP configuration
2. Run the server
3. Inspect using MCP inspector (see resulting screenshot in additional context)

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [X] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [X] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---
<img width="838" height="665" alt="image" src="https://github.com/user-attachments/assets/5eeb7bff-a147-4ba1-8508-72f23e6930bf" />

