### PR TITLE
Bugfix/tool access limitation

### DIFF
--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -31,6 +31,15 @@ export const MCP_ANNOTATION_PROPS = {
 };
 
 /**
+ * Set of annotations used for CDS auth annotations
+ * Maps logical names to their actual annotation keys used in CDS files.
+ */
+export const CDS_AUTH_ANNOTATIONS = {
+  REQUIRES: "@requires",
+  RESTRICT: "@restrict",
+};
+
+/**
  * Default set of all available OData query options for MCP resources
  * Used when @mcp.resource is set to `true` to enable all capabilities
  * Includes: $filter, $orderby, $top, $skip, $select

--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -118,7 +118,15 @@ function parseAnnotations(
   };
 
   for (const [k, v] of Object.entries(definition as any)) {
-    if (!k.includes(MCP_ANNOTATION_KEY)) continue;
+    // Process MCP annotations and CDS auth annotations
+    if (
+      !k.includes(MCP_ANNOTATION_KEY) &&
+      !k.startsWith("@requires") &&
+      !k.startsWith("@restrict")
+    ) {
+      continue;
+    }
+
     LOGGER.debug("Parsing: ", k, v);
     switch (k) {
       case MCP_ANNOTATION_PROPS.MCP_NAME:
@@ -145,6 +153,7 @@ function parseAnnotations(
         continue;
       case CDS_AUTH_ANNOTATIONS.RESTRICT:
         annotations.restrict = v as CdsRestriction[];
+        continue;
       default:
         continue;
     }

--- a/src/annotations/structures.ts
+++ b/src/annotations/structures.ts
@@ -81,7 +81,7 @@ export class McpAnnotation {
    * @returns List of required roles
    */
   get restrictions(): McpRestriction[] {
-    return this.restrictions;
+    return this._restrictions;
   }
 }
 

--- a/src/annotations/structures.ts
+++ b/src/annotations/structures.ts
@@ -2,6 +2,7 @@ import {
   McpAnnotationPrompt,
   McpResourceOption,
   McpAnnotationWrap,
+  McpRestriction,
 } from "./types";
 
 /**
@@ -17,6 +18,8 @@ export class McpAnnotation {
   protected readonly _target: string;
   /** The name of the CAP service this annotation belongs to */
   protected readonly _serviceName: string;
+  /** Auth roles by providing CDS that is required for use */
+  protected readonly _restrictions: McpRestriction[];
 
   /**
    * Creates a new MCP annotation instance
@@ -24,17 +27,20 @@ export class McpAnnotation {
    * @param description - Human-readable description
    * @param target - The target element this annotation applies to
    * @param serviceName - Name of the associated CAP service
+   * @param restrictions - Roles required for the given annotation
    */
   constructor(
     name: string,
     description: string,
     target: string,
     serviceName: string,
+    restrictions: McpRestriction[],
   ) {
     this._name = name;
     this._description = description;
     this._target = target;
     this._serviceName = serviceName;
+    this._restrictions = restrictions;
   }
 
   /**
@@ -68,6 +74,15 @@ export class McpAnnotation {
   get serviceName(): string {
     return this._serviceName;
   }
+
+  /**
+   * Gets the list of roles required for access to the annotation.
+   * If the list is empty, then all can access.
+   * @returns List of required roles
+   */
+  get restrictions(): McpRestriction[] {
+    return this.restrictions;
+  }
 }
 
 /**
@@ -93,6 +108,7 @@ export class McpResourceAnnotation extends McpAnnotation {
    * @param functionalities - Set of enabled OData query options (filter, top, skip, etc.)
    * @param properties - Map of entity properties to their CDS types
    * @param resourceKeys - Map of key fields to their types
+   * @param restrictions - Optional restrictions based on CDS roles
    */
   constructor(
     name: string,
@@ -103,8 +119,9 @@ export class McpResourceAnnotation extends McpAnnotation {
     properties: Map<string, string>,
     resourceKeys: Map<string, string>,
     wrap?: McpAnnotationWrap,
+    restrictions?: McpRestriction[],
   ) {
-    super(name, description, target, serviceName);
+    super(name, description, target, serviceName, restrictions ?? []);
     this._functionalities = functionalities;
     this._properties = properties;
     this._resourceKeys = resourceKeys;
@@ -167,6 +184,7 @@ export class McpToolAnnotation extends McpAnnotation {
    * @param entityKey - Optional entity key field for bound operations
    * @param operationKind - Optional operation type ('function' or 'action')
    * @param keyTypeMap - Optional map of key fields to types for bound operations
+   * @param restrictions - Optional restrictions based on CDS roles
    */
   constructor(
     name: string,
@@ -177,8 +195,9 @@ export class McpToolAnnotation extends McpAnnotation {
     entityKey?: string,
     operationKind?: string,
     keyTypeMap?: Map<string, string>,
+    restrictions?: McpRestriction[],
   ) {
-    super(name, description, operation, serviceName);
+    super(name, description, operation, serviceName, restrictions ?? []);
     this._parameters = parameters;
     this._entityKey = entityKey;
     this._operationKind = operationKind;
@@ -239,7 +258,7 @@ export class McpPromptAnnotation extends McpAnnotation {
     serviceName: string,
     prompts: McpAnnotationPrompt[],
   ) {
-    super(name, description, serviceName, serviceName);
+    super(name, description, serviceName, serviceName, []);
     this._prompts = prompts;
   }
 

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -14,6 +14,39 @@ import {
 export type McpDataType = "prompt" | "tool" | "resource";
 
 /**
+ * CDS restriction types
+ */
+export type CdsRestrictionType =
+  | "READ"
+  | "UPDATE"
+  | "CREATE"
+  | "DELETE"
+  | "*"
+  | "CHANGE";
+
+/**
+ * Object type for the standard @restriction annotation for CDS
+ */
+export interface CdsRestriction {
+  grant: CdsRestrictionType[];
+  to?: string[];
+  where?: string;
+}
+
+/**
+ * MCP parsed restriction types
+ */
+export type McpRestrictionType = "CREATE" | "READ" | "UPDATE" | "DELETE";
+
+/**
+ * Restriction mapping for MCP
+ */
+export interface McpRestriction {
+  role: string;
+  operations?: McpRestrictionType[];
+}
+
+/**
  * OData query capabilities that can be enabled for MCP resources
  * Each option corresponds to a specific OData v4 query parameter
  */
@@ -72,6 +105,14 @@ export type McpAnnotationStructure = {
    * Optional wrapper configuration to expose resources as tools
    */
   wrap?: McpAnnotationWrap;
+  /**
+   * Requirement for authorization annotated on element
+   */
+  requires?: string;
+  /**
+   * Restriction of access to annotated element
+   */
+  restrict?: CdsRestriction[];
 };
 
 /**

--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -324,6 +324,7 @@ function mapOperationRestriction(
         result.push("READ");
         result.push("UPDATE");
         result.push("DELETE");
+        continue;
       default:
         result.push(el as McpRestrictionType);
         continue;

--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -1,6 +1,13 @@
 import { csn } from "@sap/cds";
 import { DEFAULT_ALL_RESOURCE_OPTIONS, MCP_ANNOTATION_KEY } from "./constants";
-import { McpAnnotationStructure, McpResourceOption } from "./types";
+import {
+  CdsRestriction,
+  CdsRestrictionType,
+  McpAnnotationStructure,
+  McpResourceOption,
+  McpRestriction,
+  McpRestrictionType,
+} from "./types";
 import { LOGGER } from "../logger";
 
 /**
@@ -251,5 +258,77 @@ export function parseEntityKeys(
 
     result.set(k, v.type.replace("cds.", ""));
   }
+  return result;
+}
+
+/**
+ * Parses the CDS role restrictions to be used for MCP
+ */
+export function parseCdsRestrictions(
+  restrictions: CdsRestriction[] | undefined,
+  requires: string | undefined,
+): McpRestriction[] {
+  if (!restrictions && !requires) return [];
+
+  const result: McpRestriction[] = [];
+  if (requires) {
+    result.push({
+      role: requires,
+    });
+  }
+
+  if (!restrictions || restrictions.length <= 0) return result;
+  for (const el of restrictions) {
+    const ops = mapOperationRestriction(el.grant);
+    if (!el.to) {
+      result.push({
+        role: "authenticated-user",
+        operations: ops,
+      });
+      continue;
+    }
+
+    const mapped: McpRestriction[] = el.to.map((to) => ({
+      role: to,
+      operations: ops,
+    }));
+
+    result.push(...mapped);
+  }
+  return result;
+}
+
+/**
+ * Maps the "grant" property from CdsRestriction to McpRestriction
+ */
+function mapOperationRestriction(
+  cdsRestrictions: CdsRestrictionType[],
+): McpRestrictionType[] {
+  const result: McpRestrictionType[] = [];
+
+  if (!cdsRestrictions || cdsRestrictions.length <= 0) {
+    result.push("CREATE");
+    result.push("READ");
+    result.push("UPDATE");
+    result.push("DELETE");
+    return result;
+  }
+
+  for (const el of cdsRestrictions) {
+    switch (el) {
+      case "CHANGE":
+        result.push("UPDATE");
+        continue;
+      case "*":
+        result.push("CREATE");
+        result.push("READ");
+        result.push("UPDATE");
+        result.push("DELETE");
+      default:
+        result.push(el as McpRestrictionType);
+        continue;
+    }
+  }
+
   return result;
 }

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -254,6 +254,9 @@ export function hasToolOperationAccess(
   user: User,
   roles: McpRestriction[],
 ): boolean {
+  // If no restrictions are defined, allow access
+  if (!roles || roles.length === 0) return true;
+
   for (const el of roles) {
     if (user.is(el.role)) return true;
   }
@@ -280,6 +283,16 @@ export function getWrapAccesses(
   user: User,
   restrictions: McpRestriction[],
 ): WrapAccess {
+  // If no restrictions are defined, allow all access
+  if (!restrictions || restrictions.length === 0) {
+    return {
+      canRead: true,
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+    };
+  }
+
   const access: WrapAccess = {};
 
   for (const el of restrictions) {

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { McpResourceAnnotation } from "../annotations/structures";
-import { getAccessRights } from "../auth/utils";
+import { getAccessRights, WrapAccess } from "../auth/utils";
 import { LOGGER } from "../logger";
 import { determineMcpParameterType, toolError, asMcpResult } from "./utils";
 import { EntityOperationMode, EntityListQueryArgs } from "./types";
@@ -89,6 +89,7 @@ export function registerEntityWrappers(
   server: McpServer,
   authEnabled: boolean,
   defaultModes: EntityOperationMode[],
+  accesses: WrapAccess,
 ): void {
   const CDS = (global as any).cds;
   LOGGER.debug(
@@ -97,30 +98,33 @@ export function registerEntityWrappers(
   );
   const modes = resAnno.wrap?.modes ?? defaultModes;
 
-  if (modes.includes("query")) {
+  if (modes.includes("query") && accesses.canRead) {
     registerQueryTool(resAnno, server, authEnabled);
   }
   if (
     modes.includes("get") &&
     resAnno.resourceKeys &&
-    resAnno.resourceKeys.size > 0
+    resAnno.resourceKeys.size > 0 &&
+    accesses.canRead
   ) {
     registerGetTool(resAnno, server, authEnabled);
   }
-  if (modes.includes("create")) {
+  if (modes.includes("create") && accesses.canCreate) {
     registerCreateTool(resAnno, server, authEnabled);
   }
   if (
     modes.includes("update") &&
     resAnno.resourceKeys &&
-    resAnno.resourceKeys.size > 0
+    resAnno.resourceKeys.size > 0 &&
+    accesses.canUpdate
   ) {
     registerUpdateTool(resAnno, server, authEnabled);
   }
   if (
     modes.includes("delete") &&
     resAnno.resourceKeys &&
-    resAnno.resourceKeys.size > 0
+    resAnno.resourceKeys.size > 0 &&
+    accesses.canDelete
   ) {
     registerDeleteTool(resAnno, server, authEnabled);
   }

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,5 +1,4 @@
 import { McpResourceAnnotation } from "../annotations/structures";
-import { LOGGER } from "../logger";
 import { MCP_SESSION_HEADER, NEW_LINE } from "./constants";
 import { McpSession } from "./types";
 import { Request, Response } from "express";

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -80,6 +80,11 @@ service CatalogService {
   function getAuthor(input : String)             returns String;
 
   @requires: 'author-specialist'
+  @mcp     : {
+    name       : 'get-author-details',
+    description: 'Gets the desired authors details',
+    tool       : true
+  }
   function getAuthorDetails()                    returns String;
 
   annotate getAuthor with @requires: 'book-keeper';

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -72,13 +72,15 @@ service CatalogService {
     function getMultiKey() returns String;
   }
 
-  @mcp     : {
+  @mcp: {
     name       : 'get-author',
     description: 'Gets the desired author',
     tool       : true
   }
-  @requires: 'author-specialist'
   function getAuthor(input : String)             returns String;
+
+  @requires: 'author-specialist'
+  function getAuthorDetails()                    returns String;
 
   annotate getAuthor with @requires: 'book-keeper';
 

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -18,8 +18,13 @@ service CatalogService {
   // Wrap Books entity as tools for query/get/create/update (demo)
   annotate CatalogService.Books with @mcp.wrap: {
     tools: true,
-    modes: ['query','get','create','update'],
-    hint: 'Use for read and write demo operations'
+    modes: [
+      'query',
+      'get',
+      'create',
+      'update'
+    ],
+    hint : 'Use for read and write demo operations'
   };
 
   extend projection Books with actions {
@@ -39,6 +44,23 @@ service CatalogService {
   }
   entity Authors          as projection on my.Authors;
 
+  @restrict: [
+    {
+      grant: ['READ'],
+      to   : ['read-role']
+    },
+    {
+      grant: [
+        'CREATE',
+        'UPDATE'
+      ],
+      to   : ['maintainer']
+    },
+    {
+      grant: ['*'],
+      to   : ['admin']
+    }
+  ]
   entity MultiKeyExamples as projection on my.MultiKeyExample;
 
   extend projection MultiKeyExamples with actions {
@@ -50,12 +72,15 @@ service CatalogService {
     function getMultiKey() returns String;
   }
 
-  @mcp: {
+  @mcp     : {
     name       : 'get-author',
     description: 'Gets the desired author',
     tool       : true
   }
+  @requires: 'author-specialist'
   function getAuthor(input : String)             returns String;
+
+  annotate getAuthor with @requires: 'book-keeper';
 
   @mcp: {
     name       : 'books-by-author',

--- a/test/unit/annotations/parser.spec.ts
+++ b/test/unit/annotations/parser.spec.ts
@@ -47,6 +47,39 @@ describe("Parser", () => {
       expect(annotation).toBeInstanceOf(McpResourceAnnotation);
       expect(annotation!.name).toBe("Test Entity");
       expect(annotation!.serviceName).toBe("TestService");
+      expect((annotation as McpResourceAnnotation).restrictions).toEqual([]);
+    });
+
+    test("should parse entity with resource annotation and restrictions", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestEntity": {
+            kind: "entity",
+            "@mcp.name": "Test Entity",
+            "@mcp.description": "Test entity description",
+            "@mcp.resource": true,
+            "@restrict": [
+              {
+                grant: ["READ"],
+                to: ["read-role"],
+              },
+            ],
+            elements: {
+              id: { type: "cds.UUID", key: true },
+              name: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("TestEntity") as McpResourceAnnotation;
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation.restrictions).toEqual([
+        { role: "read-role", operations: ["READ"] },
+      ]);
     });
 
     test("should parse function with tool annotation", () => {
@@ -70,6 +103,31 @@ describe("Parser", () => {
       const annotation = result.get("TestFunction");
       expect(annotation).toBeInstanceOf(McpToolAnnotation);
       expect(annotation!.name).toBe("Test Function");
+      expect((annotation as McpToolAnnotation).restrictions).toEqual([]);
+    });
+
+    test("should parse function with tool annotation and requires", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestFunction": {
+            kind: "function",
+            "@mcp.name": "Test Function",
+            "@mcp.description": "Test function description",
+            "@mcp.tool": true,
+            "@requires": "author-specialist",
+            params: {
+              input: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("TestFunction") as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation.restrictions).toEqual([{ role: "author-specialist" }]);
     });
 
     test("should parse service with prompts annotation", () => {

--- a/test/unit/annotations/structures.spec.ts
+++ b/test/unit/annotations/structures.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   McpResourceOption,
   McpAnnotationPrompt,
+  McpRestriction,
 } from "../../../src/annotations/types";
 
 describe("McpAnnotation", () => {
@@ -18,6 +19,7 @@ describe("McpAnnotation", () => {
       "test-description",
       "test-target",
       "test-service",
+      [],
     );
   });
 
@@ -26,14 +28,31 @@ describe("McpAnnotation", () => {
     expect(annotation.description).toBe("test-description");
     expect(annotation.target).toBe("test-target");
     expect(annotation.serviceName).toBe("test-service");
+    expect(annotation.restrictions).toEqual([]);
   });
 
   test("should handle empty strings", () => {
-    const emptyAnnotation = new McpAnnotation("", "", "", "");
+    const emptyAnnotation = new McpAnnotation("", "", "", "", []);
     expect(emptyAnnotation.name).toBe("");
     expect(emptyAnnotation.description).toBe("");
     expect(emptyAnnotation.target).toBe("");
     expect(emptyAnnotation.serviceName).toBe("");
+    expect(emptyAnnotation.restrictions).toEqual([]);
+  });
+
+  test("should create instance with restrictions", () => {
+    const restrictions: McpRestriction[] = [
+      { role: "admin", operations: ["READ", "UPDATE"] },
+      { role: "user", operations: ["READ"] },
+    ];
+    const annotationWithRestrictions = new McpAnnotation(
+      "test-name",
+      "test-description",
+      "test-target",
+      "test-service",
+      restrictions,
+    );
+    expect(annotationWithRestrictions.restrictions).toEqual(restrictions);
   });
 });
 
@@ -85,6 +104,24 @@ describe("McpResourceAnnotation", () => {
     expect(emptyAnnotation.properties.size).toBe(0);
     expect(emptyAnnotation.resourceKeys.size).toBe(0);
   });
+
+  test("should create resource annotation with restrictions", () => {
+    const restrictions: McpRestriction[] = [
+      { role: "read-role", operations: ["READ"] },
+    ];
+    const annotationWithRestrictions = new McpResourceAnnotation(
+      "resource-name",
+      "resource-description",
+      "resource-target",
+      "resource-service",
+      new Set(["filter"]),
+      new Map([["id", "UUID"]]),
+      new Map([["id", "UUID"]]),
+      undefined,
+      restrictions,
+    );
+    expect(annotationWithRestrictions.restrictions).toEqual(restrictions);
+  });
 });
 
 describe("McpToolAnnotation", () => {
@@ -127,6 +164,22 @@ describe("McpToolAnnotation", () => {
     expect(annotation.entityKey).toBeUndefined();
     expect(annotation.operationKind).toBeUndefined();
     expect(annotation.keyTypeMap).toBeUndefined();
+  });
+
+  test("should create tool annotation with restrictions", () => {
+    const restrictions: McpRestriction[] = [{ role: "author-specialist" }];
+    const annotation = new McpToolAnnotation(
+      "tool-name",
+      "tool-description",
+      "tool-operation",
+      "tool-service",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      restrictions,
+    );
+    expect(annotation.restrictions).toEqual(restrictions);
   });
 });
 

--- a/test/unit/mcp/entity-tools.spec.ts
+++ b/test/unit/mcp/entity-tools.spec.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerEntityWrappers } from "../../../src/mcp/entity-tools";
 import { McpResourceAnnotation } from "../../../src/annotations/structures";
+import { WrapAccess } from "../../../src/auth/utils";
 
 describe("entity-tools - registration", () => {
   it("registers query/get/create/update/delete based on modes", () => {
@@ -27,7 +28,13 @@ describe("entity-tools - registration", () => {
       { tools: true, modes: ["query", "get", "create", "update", "delete"] },
     );
 
-    registerEntityWrappers(res, server, false, ["query", "get"]);
+    const accesses: WrapAccess = {
+      canRead: true,
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+    };
+    registerEntityWrappers(res, server, false, ["query", "get"], accesses);
 
     expect(reg).toEqual(
       expect.arrayContaining([
@@ -64,7 +71,8 @@ describe("entity-tools - registration", () => {
       { tools: true, modes: ["delete"] },
     );
 
-    registerEntityWrappers(res, server, false, []);
+    const accesses: WrapAccess = { canDelete: true };
+    registerEntityWrappers(res, server, false, ["delete"], accesses);
 
     expect(reg).toEqual(["CatalogService_Books_delete"]);
   });
@@ -93,7 +101,8 @@ describe("entity-tools - registration", () => {
       { tools: true, modes: ["delete"] },
     );
 
-    registerEntityWrappers(res, server, false, []);
+    const accesses: WrapAccess = { canDelete: true };
+    registerEntityWrappers(res, server, false, ["delete"], accesses);
 
     expect(reg).toEqual([]);
   });

--- a/test/unit/mcp/factory.spec.ts
+++ b/test/unit/mcp/factory.spec.ts
@@ -50,6 +50,22 @@ jest.mock("../../../src/logger", () => ({
   },
 }));
 
+jest.mock("../../../src/auth/utils", () => ({
+  isAuthEnabled: jest.fn(() => false),
+  getAccessRights: jest.fn(() => ({ is: () => true })),
+  hasToolOperationAccess: jest.fn(() => true),
+  getWrapAccesses: jest.fn(() => ({
+    canRead: true,
+    canCreate: true,
+    canUpdate: true,
+    canDelete: true,
+  })),
+}));
+
+jest.mock("../../../src/mcp/entity-tools", () => ({
+  registerEntityWrappers: jest.fn(),
+}));
+
 describe("Factory", () => {
   let mockConfig: CAPConfiguration;
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Implements authorization check against @requires and @restrict annotations when connecting to MCP server, such that only the tools that the user has access to per their authorization gets exposed to the agent. 

Made based on request in https://github.com/gavdilabs/cap-mcp-plugin/issues/22 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to https://github.com/gavdilabs/cap-mcp-plugin/issues/22
- Fixes https://github.com/gavdilabs/cap-mcp-plugin/issues/22

## What Changed

<!-- List the main changes made -->
- Parser changes to catch @restrict and @requires annotations for service 
- Access checks at MCP connection initialization
- Automated tests added to cover implementation

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Add MCP plugin to CAP service with restrictions to resources
2. Using Inspector or AI Agent, connect to the server through principal propogation access 
3. Verify that roles used for user reflects that access seen in the tool/resource list

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [X] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [X] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

