### PR TITLE
fix: improve query description

### DIFF
--- a/docs/entity-tools.md
+++ b/docs/entity-tools.md
@@ -50,6 +50,8 @@ Recommended defaults: enable only `query` and `get` globally; opt into `create`/
 
 - `query`: structured inputs validated by zod
   - `top`, `skip`, `select`, `orderby`, `where`, `q`, `return` (rows|count|aggregate), `aggregate`
+  - **All fields are consistent**: use foreign key fields (e.g., `author_ID`) for associations
+  - Both `select` and `where` support the same field set: scalars + foreign keys
   - `q` performs a simple string contains on string fields
   - `return: 'count'` returns `{ count: number }`
   - `return: 'aggregate'` returns aggregation rows

--- a/src/mcp/describe-model.ts
+++ b/src/mcp/describe-model.ts
@@ -95,7 +95,7 @@ export function registerDescribeModelTool(server: McpServer): void {
             rationale:
               "Entity wrapper tools expose CRUD-like operations for LLMs. Prefer query/get globally; create/update must be explicitly enabled by the developer.",
             guidance:
-              "Use the *_query tool for retrieval with filters and projections. select/orderby support only scalar fields (no associations). To filter by an association, use the association field name with the key value (e.g., {field:'author',op:'eq',value:4}). Use *_get with keys for a single record; use *_create/*_update only if enabled and necessary.",
+              "Use the *_query tool for retrieval with filters and projections. All fields in select/where are consistent. For associations, use foreign key fields (e.g., author_ID not author). Use *_get with keys for a single record; use *_create/*_update only if enabled and necessary.",
           },
           examples: {
             list_tool: listName,

--- a/src/mcp/describe-model.ts
+++ b/src/mcp/describe-model.ts
@@ -73,7 +73,11 @@ export function registerDescribeModelTool(server: McpServer): void {
 
         const keys = elements.filter((e) => e.key).map((e) => e.name);
         const sampleTop = 5;
-        const shortFields = elements.slice(0, 5).map((e) => e.name);
+        // Prefer scalar fields for sample selects; exclude associations
+        const scalarFields = elements
+          .filter((e) => String(e.type).toLowerCase() !== "cds.association")
+          .map((e) => e.name);
+        const shortFields = scalarFields.slice(0, 5);
 
         // Match wrapper tool naming: Service_Entity_mode
         const entName = String(ent?.name || "entity");
@@ -91,7 +95,7 @@ export function registerDescribeModelTool(server: McpServer): void {
             rationale:
               "Entity wrapper tools expose CRUD-like operations for LLMs. Prefer query/get globally; create/update must be explicitly enabled by the developer.",
             guidance:
-              "Use the *_query tool for retrieval with filters and projections; use *_get with keys for a single record; use *_create/*_update only if enabled and necessary.",
+              "Use the *_query tool for retrieval with filters and projections. select/orderby support only scalar fields (no associations). To filter by an association, use the association field name with the key value (e.g., {field:'author',op:'eq',value:4}). Use *_get with keys for a single record; use *_create/*_update only if enabled and necessary.",
           },
           examples: {
             list_tool: listName,

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -90,7 +90,7 @@ function buildEnhancedQueryDescription(resAnno: McpResourceAnnotation): string {
   const baseDesc = `Query ${resAnno.target} with structured filters, select, orderby, top/skip.`;
   const assocHint =
     associations.length > 0
-      ? ` Foreign keys (${associations.join(", ")}) available for filtering by association ID.`
+      ? ` IMPORTANT: For associations, always use foreign key fields (${associations.join(", ")}) - never use association names directly.`
       : "";
 
   return baseDesc + assocHint;
@@ -262,7 +262,7 @@ function registerQueryTool(
         .array(
           z.object({
             field: whereFieldEnum.describe(
-              `Available fields: ${scalarKeys.join(", ")} (use foreign key fields like author_ID for associations)`,
+              `FILTERABLE FIELDS: ${scalarKeys.join(", ")}. For associations use foreign key (author_ID), NOT association name (author).`,
             ),
             op: z.enum([
               "eq",
@@ -322,7 +322,7 @@ function registerQueryTool(
 
   const hint = resAnno.wrap?.hint ? ` Hint: ${resAnno.wrap?.hint}` : "";
   const desc =
-    `${buildEnhancedQueryDescription(resAnno)} All fields in select/where are consistent - use foreign key fields (e.g., author_ID) for associations.` +
+    `${buildEnhancedQueryDescription(resAnno)} CRITICAL: Use foreign key fields (e.g., author_ID) for associations - association names (e.g., author) won't work in filters.` +
     hint;
 
   const queryHandler = async (rawArgs: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary

Fix critical UX inconsistency in MCP entity tools where association field names were mixed between `author` (in where clauses) and `author_ID` (in data), causing LLM confusion and query failures. This PR standardizes all field references to use foreign key naming (`author_ID`) consistently across select, where, and returned data.

## Type of Change

- [x] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [x] 🚀 **Feature** - New functionality or enhancement (improved LLM experience)

## Related Issues

- Fixes user-reported field name inconsistency causing tool call failures
- Resolves "unknown" types appearing in tool descriptions
- Addresses `FILTER_PARSE_ERROR` with empty arrays and `q` parameter

## What Changed

- **Standardized field naming**: All entity tools now use foreign key fields (`author_ID`) consistently in schemas, descriptions, and query building
- **Fixed empty array handling**: Added `.transform()` to convert empty arrays to `undefined` for select/where/orderby/aggregate parameters
- **Improved `q` parameter logic**: Fixed quick search to build single CDS expression instead of parsing individual expressions
- **Enhanced tool descriptions**: Clearer, more explicit guidance about using foreign key fields for associations
- **Updated documentation**: Reflected consistent field naming approach in entity-tools.md

## Testing

- [x] Unit tests pass
- [x] Integration tests pass  
- [x] Manual testing completed
- [x] No new warnings/errors

**Test Steps:**
1. Start demo server: `npm run mock:watch` 
2. Connect MCP client: `npm run inspect`
3. Test query with association filter: `{"where":[{"field":"author_ID","op":"eq","value":4}],"select":["ID","title","author_ID"]}`
4. Test quick search: `{"q":"Agatha Christie"}`
5. Verify consistent field names in tool descriptions and returned data

## Impact

- [x] API changes (documented below)
- [x] Documentation updated

**API Changes:**
- Entity tool schemas now expose `author_ID` instead of `author` in field enums
- Tool descriptions explicitly mention foreign key field usage
- Query responses return foreign key fields consistently

## Review Focus

- [x] Code quality and architecture
- [x] Test coverage and quality  
- [x] Documentation accuracy

**Key Areas:**
- `buildEnhancedQueryDescription()` - simplified and clarified association handling
- `registerQueryTool()` - consistent field enum generation for select/where
- `buildQuery()` - removed complex field mapping, direct foreign key usage
- Updated guidance in `describe-model.ts` and `docs/entity-tools.md`

## Additional Context

**Before (Confusing):**
```json
// Schema showed mixed fields
"select": ["ID", "title", "stock"]           // scalars only
"where": ["ID", "title", "author", "author_ID"] // mixed naming

// LLM confusion
{"where": [{"field": "author", "op": "eq", "value": 4}], "select": ["author"]} // ❌ Fails
```

**After (Consistent):**
```json  
// Schema shows consistent fields
"select": ["ID", "title", "stock", "author_ID"]  // scalars + foreign keys
"where": ["ID", "title", "stock", "author_ID"]   // same fields

// Clear LLM usage  
{"where": [{"field": "author_ID", "op": "eq", "value": 4}], "select": ["author_ID"]} // ✅ Works
```

This change significantly improves the LLM developer experience by eliminating field name confusion and providing predictable, consistent behavior across all entity operations.

## Before:

<img width="847" height="1127" alt="image" src="https://github.com/user-attachments/assets/94a9ab0d-6094-4262-8369-0883addd24ca" />

## After

<img width="765" height="674" alt="image" src="https://github.com/user-attachments/assets/bed91680-1b4b-454e-a0c2-29ba43131d4c" />
