### PR TITLE
fix: Stop parsing if no definitions or elements

### DIFF
--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -270,6 +270,9 @@ export function parseEntityKeys(
   definition: csn.Definition,
 ): Map<string, string> {
   const result = new Map<string, string>();
+
+  if (!definition?.elements) return result; // If there is no defined elements, we exit early
+
   for (const [k, v] of Object.entries(definition.elements)) {
     if (!v.key) continue;
     if (!v.type) {

--- a/test/unit/annotations/utils.spec.ts
+++ b/test/unit/annotations/utils.spec.ts
@@ -16,7 +16,6 @@ import {
   McpAnnotationStructure,
   McpResourceOption,
   CdsRestriction,
-  McpRestriction,
 } from "../../../src/annotations/types";
 import { csn } from "@sap/cds";
 
@@ -425,6 +424,20 @@ describe("Utils", () => {
       expect(result.size).toBe(2);
       expect(result.get("id")).toBe("UUID");
       expect(result.get("secondaryId")).toBe("String");
+    });
+
+    test("should return empty result if there is no definition object", () => {
+      const definition = undefined;
+      const result = parseEntityKeys(definition as any);
+
+      expect(result.size).toBe(0);
+    });
+
+    test("should return empty result if there is no elements defined in definition", () => {
+      const definition = {};
+      const result = parseEntityKeys(definition as any);
+
+      expect(result.size).toBe(0);
     });
 
     test("should throw error for key without type", () => {


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Implements a check for parseEntityKeys where if there are no definitions on the object, we return an empty result instead of throwing an error. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [X] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #
- Fixes #

## What Changed

<!-- List the main changes made -->
- parseEntityKeys now checks if definition or definition.elements is valid before parsing

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Test that tools, resources and prompts return as expected

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

