### PR TITLE
fix: ts build undefined definition elements

### DIFF
--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -218,7 +218,7 @@ export function parseResourceElements(definition: csn.Definition): {
   const properties = new Map<string, string>();
   const resourceKeys = new Map<string, string>();
 
-  for (const [key, value] of Object.entries(definition.elements)) {
+  for (const [key, value] of Object.entries(definition.elements || {})) {
     if (!value.type) continue;
     const parsedType = value.type.replace("cds.", "");
     properties.set(key, parsedType);


### PR DESCRIPTION
## Summary

During the build process (`cds build`) the plugin receives the `loaded` event and parses all annotations. A build task for `typescript` seems to trigger this event twice where the first iteration does not contain an `elements` property in the csnDefinition. So we have to handle `undefined` for this.

## Testing

<!-- Mark completed testing with "x" -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] No new warnings/errors


