### PR TITLE
feat: support @mcp.cdsType annotation

### DIFF
--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -30,6 +30,8 @@ export const MCP_ANNOTATION_PROPS = {
   MCP_WRAP: "@mcp.wrap",
   /** Elicited user input annotation for tools in CAP services */
   MCP_ELICIT: "@mcp.elicit",
+  /** Fallback type for custom-typed properties */
+  MCP_CDSTYPE: "@mcp.cdsType",
 };
 
 /**

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -88,6 +88,7 @@ export type McpReferenceAnnotationStructure = {
   "@mcp.resource"?: boolean | Array<McpResourceOption>;
   "@mcp.tool"?: boolean;
   "@prompts"?: McpAnnotationPrompt[];
+  "@mcp.cdsType"?: string;
 };
 
 /**
@@ -118,6 +119,10 @@ export type McpAnnotationStructure = {
    * Elicited user input annotated element
    */
   elicit?: McpElicit[];
+  /**
+   * Fallback type for custom-typed properties
+   */
+  cdsType?: string;
 };
 
 /**

--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -1,5 +1,9 @@
 import { csn } from "@sap/cds";
-import { DEFAULT_ALL_RESOURCE_OPTIONS, MCP_ANNOTATION_KEY } from "./constants";
+import {
+  DEFAULT_ALL_RESOURCE_OPTIONS,
+  MCP_ANNOTATION_KEY,
+  MCP_ANNOTATION_PROPS,
+} from "./constants";
 import {
   CdsRestriction,
   CdsRestrictionType,
@@ -244,13 +248,15 @@ export function parseOperationElements(annotations: McpAnnotationStructure): {
 } {
   let parameters: Map<string, string> | undefined;
 
-  const params: { [key: string]: { type: string } } = (
-    annotations.definition as any
-  )["params"];
+  const params: Record<string, any> = (annotations.definition as any)["params"];
   if (params && Object.entries(params).length > 0) {
     parameters = new Map<string, string>();
     for (const [k, v] of Object.entries(params)) {
-      parameters.set(k, v.type.replace("cds.", ""));
+      const cdsType: string =
+        typeof v.type == "string"
+          ? v.type
+          : v[MCP_ANNOTATION_PROPS.MCP_CDSTYPE];
+      parameters.set(k, cdsType.replace("cds.", ""));
     }
   }
 

--- a/test/unit/annotations/constants.spec.ts
+++ b/test/unit/annotations/constants.spec.ts
@@ -19,6 +19,7 @@ describe("Annotations - Constants", () => {
       expect(MCP_ANNOTATION_PROPS.MCP_RESOURCE).toBe("@mcp.resource");
       expect(MCP_ANNOTATION_PROPS.MCP_TOOL).toBe("@mcp.tool");
       expect(MCP_ANNOTATION_PROPS.MCP_PROMPT).toBe("@mcp.prompts");
+      expect(MCP_ANNOTATION_PROPS.MCP_CDSTYPE).toBe("@mcp.cdsType");
     });
   });
 

--- a/test/unit/annotations/parser.spec.ts
+++ b/test/unit/annotations/parser.spec.ts
@@ -203,6 +203,40 @@ describe("Parser", () => {
       expect(annotation!.name).toBe("Bound Action");
     });
 
+    test("should parse bound operations with custom-typed parameter", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestEntity": {
+            kind: "entity",
+            elements: {
+              id: { type: "cds.UUID", key: true },
+            },
+            actions: {
+              boundAction: {
+                kind: "action",
+                "@mcp.name": "Bound Action",
+                "@mcp.description": "Bound action description",
+                "@mcp.tool": true,
+                params: {
+                  input: {
+                    "@mcp.cdsType": "cds.Double",
+                    type: { ref: ["myTypes.CustomDouble", "double1"] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("boundAction");
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation!.name).toBe("Bound Action");
+    });
+
     test("should handle mixed valid and invalid definitions", () => {
       const model: csn.CSN = {
         definitions: {

--- a/test/unit/annotations/utils.spec.ts
+++ b/test/unit/annotations/utils.spec.ts
@@ -407,6 +407,31 @@ describe("Utils", () => {
       expect(result.parameters).toBeUndefined();
       expect(result.operationKind).toBe("action");
     });
+
+    test("should parse custom-typed operation elements correctly", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "function",
+          params: {
+            param1: { type: "cds.String" },
+            param2: {
+              "@mcp.cdsType": "cds.Double",
+              type: { ref: ["myTypes.CustomDouble", "double1"] },
+            },
+          },
+        } as any,
+        name: "test",
+        description: "test",
+      };
+
+      const result = parseOperationElements(annotations);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.size).toBe(2);
+      expect(result.parameters!.get("param1")).toBe("String");
+      expect(result.parameters!.get("param2")).toBe("Double");
+      expect(result.operationKind).toBe("function");
+    });
   });
 
   describe("parseEntityKeys", () => {


### PR DESCRIPTION
## Summary

Adds a new annotation `mcp.cdsType` to handle situations where parameters of an operation (function, action) do not use cds types directly, but inherit the type from another element.

## What Changed

The below scenario would not be parsed correctly
```cds
entity Books as projection on my.Books
  actions {
    action SetStock(
        quantity: TValidQuantities:positiveOnly
    )
  };

type TValidQuantities {
  positiveOnly: Integer @assert.range: [0, _]
}
```

With this PR, the parsing will be done correctly by providing a 'fallback type' for this complex type:
```cds
entity Books as projection on my.Books
  actions {
    action SetStock(
        @mcp.cdsType: 'cds.Integer'
        quantity: TValidQuantities:positiveOnly
    )
  };

type TValidQuantities {
  positiveOnly: Integer @assert.range: [0, _]
}
```


## Testing

2 additional tests created

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] No new warnings/errors

## Review Focus

Verify if you want this 'workaround' solution, or prefer another alternative. I'm not sure if this is a common scenario, I just happened to use it in my project, hence this proposal.

