### PR TITLE
fix: Wrap annotations parsing

### DIFF
--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -26,8 +26,12 @@ export const MCP_ANNOTATION_PROPS = {
   MCP_TOOL: "@mcp.tool",
   /** Prompt templates annotation for CAP services */
   MCP_PROMPT: "@mcp.prompts",
-  /** Wrapper configuration for exposing entities as tools */
-  MCP_WRAP: "@mcp.wrap",
+  /** Wrapper configuration for exposing entities as tools - tools prop*/
+  MCP_WRAP_TOOLS: "@mcp.wrap.tools",
+  /** Wrapper configuration for exposing entities as tools - modes prop*/
+  MCP_WRAP_MODES: "@mcp.wrap.modes",
+  /** Wrapper configuration for exposing entities as tools - hint prop*/
+  MCP_WRAP_HINT: "@mcp.wrap.hint",
   /** Elicited user input annotation for tools in CAP services */
   MCP_ELICIT: "@mcp.elicit",
 };

--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -11,6 +11,7 @@ import {
   CdsRestriction,
   McpAnnotationPrompt,
   McpAnnotationStructure,
+  McpAnnotationWrap,
   ParsedAnnotations,
 } from "./types";
 import {
@@ -156,9 +157,26 @@ function parseAnnotations(
       case MCP_ANNOTATION_PROPS.MCP_PROMPT:
         annotations.prompts = v as any;
         continue;
-      case MCP_ANNOTATION_PROPS.MCP_WRAP:
-        // Wrapper container to expose resources as tools
-        annotations.wrap = v as any;
+      case MCP_ANNOTATION_PROPS.MCP_WRAP_TOOLS:
+        if (!annotations.wrap) {
+          annotations.wrap = {};
+        }
+
+        annotations.wrap.tools = v as boolean;
+        continue;
+      case MCP_ANNOTATION_PROPS.MCP_WRAP_HINT:
+        if (!annotations.wrap) {
+          annotations.wrap = {};
+        }
+
+        annotations.wrap.hint = v as string;
+        continue;
+      case MCP_ANNOTATION_PROPS.MCP_WRAP_MODES:
+        if (!annotations.wrap) {
+          annotations.wrap = {};
+        }
+
+        annotations.wrap.modes = v as any;
         continue;
       case MCP_ANNOTATION_PROPS.MCP_ELICIT:
         annotations.elicit = v as any;

--- a/src/mcp/factory.ts
+++ b/src/mcp/factory.ts
@@ -71,7 +71,8 @@ export function createMcpServer(
       const enabled =
         localWrap === true || (localWrap === undefined && globalWrap);
       if (enabled) {
-        const modes = config.wrap_entity_modes ?? ["query", "get"];
+        const modes = entry.wrap?.modes ??
+          config.wrap_entity_modes ?? ["query", "get"];
         registerEntityWrappers(entry, server, authEnabled, modes, accesses);
       }
       continue;

--- a/test/demo/package.json
+++ b/test/demo/package.json
@@ -30,9 +30,7 @@
       "wrap_entities_to_actions": true,
       "wrap_entity_modes": [
         "query",
-        "get",
-        "create",
-        "update"
+        "get"
       ]
     },
     "log": {

--- a/test/integration/http-api/mcp-entity-wrappers.spec.ts
+++ b/test/integration/http-api/mcp-entity-wrappers.spec.ts
@@ -204,7 +204,8 @@ describe("MCP HTTP API - Entity Wrappers", () => {
           "@mcp.name": "test-books",
           "@mcp.description": "Test books resource",
           "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
-          "@mcp.wrap": { tools: true, modes: ["update"] },
+          "@mcp.wrap.tools": true,
+          "@mcp.wrap.modes": ["update"],
           elements: {
             ID: { type: "cds.Integer", key: true },
             title: { type: "cds.String" },
@@ -285,5 +286,149 @@ describe("MCP HTTP API - Entity Wrappers", () => {
     expect(deleteBooksTool.description).toContain("cannot be undone");
     expect(deleteBooksTool.inputSchema).toBeDefined();
     expect(deleteBooksTool.inputSchema.properties).toHaveProperty("ID");
+  });
+
+  it("preserves existing @mcp.resource annotations when global wrap is enabled", async () => {
+    // The key test: verify that the default fixture Books entity has BOTH:
+    // 1. Resource annotation (@mcp.resource in test-server.ts line 112)
+    // 2. Wrap annotation (@mcp.wrap in test-server.ts line 113-117)
+    // 3. Global wrap is enabled (wrap_entities_to_actions: true in test-server.ts line 36)
+    // This confirms that existing annotations are preserved and enhanced by global settings
+
+    const toolsResp = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .set("mcp-session-id", sessionId)
+      .send({ jsonrpc: "2.0", id: 3, method: "tools/list" })
+      .expect(200);
+
+    const tools = toolsResp.body?.result?.tools || [];
+    const toolNames = tools.map((t: any) => t.name);
+
+    // Books should have wrap tools (explicitly defined in fixture with modes)
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "TestService_Books_query",
+        "TestService_Books_get",
+        "TestService_Books_update",
+        "TestService_Books_create",
+        "TestService_Books_delete",
+      ]),
+    );
+
+    // Books should also have the original function tool (shows original annotations preserved)
+    expect(toolNames).toEqual(expect.arrayContaining(["get-book-info"]));
+
+    // The presence of both entity wrap tools AND the original function tool
+    // confirms that global wrap settings enhance rather than overwrite existing annotations.
+    // This validates that:
+    // 1. @mcp.resource annotation is preserved (Books entity functionality)
+    // 2. @mcp.wrap annotation is preserved (explicit wrap modes)
+    // 3. @mcp.tool annotation is preserved (get-book-info function)
+    // 4. Global wrap_entities_to_actions setting works alongside existing annotations
+  });
+
+  it("respects entity-level modes when they differ from global modes", async () => {
+    // Verify precedence: global modes are ["query", "get"] but entity has ["query", "get", "create", "update", "delete"]
+    await testServer.stop();
+    const express = require("express");
+    const { default: McpPlugin } = require("../../../src/mcp");
+    const {
+      mockLoadConfiguration,
+    } = require("../../helpers/test-config-loader");
+    const { mockCdsEnvironment } = require("../../helpers/mock-config");
+    const app = express();
+    mockCdsEnvironment();
+    mockLoadConfiguration({
+      name: "Test MCP Server",
+      version: "1.0.0",
+      auth: "none",
+      capabilities: {
+        tools: { listChanged: true },
+        resources: { listChanged: true, subscribe: false },
+        prompts: { listChanged: true },
+      },
+      wrap_entities_to_actions: true,
+      wrap_entity_modes: ["query", "get"], // Global only allows query and get
+    });
+    const plugin = new McpPlugin();
+    await plugin.onBootstrap(app);
+
+    // Create CSN with entity that has MORE modes than global config
+    const model = {
+      definitions: {
+        TestService: {
+          kind: "service",
+          "@mcp.name": "test-service",
+          "@mcp.description": "Test service",
+          "@mcp.prompts": [
+            {
+              name: "p",
+              title: "t",
+              description: "d",
+              template: "x",
+              role: "user",
+              inputs: [],
+            },
+          ],
+        },
+        "TestService.Products": {
+          kind: "entity",
+          "@mcp.name": "test-products",
+          "@mcp.description": "Test products resource",
+          "@mcp.resource": ["filter", "orderby", "select", "top", "skip"],
+          "@mcp.wrap.tools": true,
+          "@mcp.wrap.modes": ["query", "get", "create", "update", "delete"], // Entity wants all modes
+          elements: {
+            ID: { type: "cds.Integer", key: true },
+            name: { type: "cds.String" },
+            price: { type: "cds.Decimal" },
+          },
+        },
+      },
+    };
+    await plugin.onLoaded(model);
+
+    const init = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {}, resources: {} },
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+    const sid = init.headers["mcp-session-id"];
+
+    const toolsResp = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .set("mcp-session-id", sid)
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+      .expect(200);
+
+    const tools = toolsResp.body?.result?.tools || [];
+    const toolNames = tools.map((t: any) => t.name);
+
+    // Verify that entity-level modes properly override global modes
+    // Global: ["query", "get"] but entity specifies: ["query", "get", "create", "update", "delete"]
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        "TestService_Products_query",
+        "TestService_Products_get",
+        "TestService_Products_create", // These prove entity modes override global
+        "TestService_Products_update", // These prove entity modes override global
+        "TestService_Products_delete", // These prove entity modes override global
+      ]),
+    );
+
+    await plugin.onShutdown();
   });
 });


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Fixes a bug introduced in version 0.9.8 where the wrap annotations no longer got parsed from the model 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes


## What Changed

<!-- List the main changes made -->
- CDS was sharing the annotations in a flat structure but parser was expecting an object, the parser has now been changed to match the reality by CDS

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Add entity with @mcp.wrap annotation where you include all operations supported
2. Add global config for only one or two features of wrap
3. Test with inspector that the expected output is given in the tools

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

