### PR TITLE
feat: enhanced wrap hints

### DIFF
--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -12,38 +12,27 @@ import { McpResourceOption } from "./types";
 export const MCP_ANNOTATION_KEY = "@mcp";
 
 /**
- * Complete set of supported MCP annotation property names
- * Maps logical names to their actual annotation keys used in CDS files
+ * Mapping of the custom annotations + CDS specific annotations and their correlated mapping for MCP usage
  */
-export const MCP_ANNOTATION_PROPS = {
-  /** Name identifier annotation - required for all MCP elements */
-  MCP_NAME: "@mcp.name",
-  /** Description annotation - required for all MCP elements */
-  MCP_DESCRIPTION: "@mcp.description",
-  /** Resource configuration annotation for CAP entities */
-  MCP_RESOURCE: "@mcp.resource",
-  /** Tool configuration annotation for CAP functions/actions */
-  MCP_TOOL: "@mcp.tool",
-  /** Prompt templates annotation for CAP services */
-  MCP_PROMPT: "@mcp.prompts",
-  /** Wrapper configuration for exposing entities as tools - tools prop*/
-  MCP_WRAP_TOOLS: "@mcp.wrap.tools",
-  /** Wrapper configuration for exposing entities as tools - modes prop*/
-  MCP_WRAP_MODES: "@mcp.wrap.modes",
-  /** Wrapper configuration for exposing entities as tools - hint prop*/
-  MCP_WRAP_HINT: "@mcp.wrap.hint",
-  /** Elicited user input annotation for tools in CAP services */
-  MCP_ELICIT: "@mcp.elicit",
-};
-
-/**
- * Set of annotations used for CDS auth annotations
- * Maps logical names to their actual annotation keys used in CDS files.
- */
-export const CDS_AUTH_ANNOTATIONS = {
-  REQUIRES: "@requires",
-  RESTRICT: "@restrict",
-};
+export const MCP_ANNOTATION_MAPPING = new Map<string, string>([
+  ["@mcp.name", "name"],
+  ["@mcp.description", "description"],
+  ["@mcp.resource", "resource"],
+  ["@mcp.tool", "tool"],
+  ["@mcp.prompts", "prompts"],
+  ["@mcp.wrap", "wrap"],
+  ["@mcp.wrap.tools", "wrap.tools"],
+  ["@mcp.wrap.modes", "wrap.modes"],
+  ["@mcp.wrap.hint", "wrap.hint"],
+  ["@mcp.wrap.hint.get", "wrap.hint.get"],
+  ["@mcp.wrap.hint.query", "wrap.hint.query"],
+  ["@mcp.wrap.hint.create", "wrap.hint.create"],
+  ["@mcp.wrap.hint.update", "wrap.hint.update"],
+  ["@mcp.wrap.hint.delete", "wrap.hint.delete"],
+  ["@mcp.elicit", "elicit"],
+  ["@requires", "requires"],
+  ["@restrict", "restrict"],
+]);
 
 /**
  * Default set of all available OData query options for MCP resources

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -129,7 +129,18 @@ export type McpAnnotationWrap = {
   /** Tool modes to create; defaults are provided via configuration */
   modes?: EntityOperationMode[];
   /** Additional description hint appended to tool descriptions */
-  hint?: string;
+  hint?: string | McpDetailedHint;
+};
+
+/**
+ * Detailed hints object for the wrapper functionality
+ */
+export type McpDetailedHint = {
+  get?: string;
+  query?: string;
+  create?: string;
+  update?: string;
+  delete?: string;
 };
 
 /**

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -22,7 +22,8 @@ service CatalogService {
       'query',
       'get',
       'create',
-      'update'
+      'update',
+      'delete'
     ],
     hint : 'Use for read and write demo operations'
   };
@@ -43,6 +44,22 @@ service CatalogService {
     resource   : true
   }
   entity Authors          as projection on my.Authors;
+
+  annotate CatalogService.Authors with @mcp.wrap: {
+    tools: true,
+    modes: [
+      'query',
+      'get',
+      'create',
+      'update'
+    ],
+    hint : {
+      query : 'Retrieves lists of data based on the query parameters provided',
+      get   : 'Retrieves a singular entity',
+      create: 'Creates a new record of an Author',
+      update: 'Update properties of a given author'
+    }
+  };
 
   @restrict: [
     {

--- a/test/unit/annotations/constants.spec.ts
+++ b/test/unit/annotations/constants.spec.ts
@@ -1,6 +1,5 @@
 import {
   MCP_ANNOTATION_KEY,
-  MCP_ANNOTATION_PROPS,
   DEFAULT_ALL_RESOURCE_OPTIONS,
 } from "../../../src/annotations/constants";
 import { McpResourceOption } from "../../../src/annotations/types";
@@ -9,16 +8,6 @@ describe("Annotations - Constants", () => {
   describe("MCP_ANNOTATION_KEY", () => {
     test("should have correct value", () => {
       expect(MCP_ANNOTATION_KEY).toBe("@mcp");
-    });
-  });
-
-  describe("MCP_ANNOTATION_PROPS", () => {
-    test("should have all required properties", () => {
-      expect(MCP_ANNOTATION_PROPS.MCP_NAME).toBe("@mcp.name");
-      expect(MCP_ANNOTATION_PROPS.MCP_DESCRIPTION).toBe("@mcp.description");
-      expect(MCP_ANNOTATION_PROPS.MCP_RESOURCE).toBe("@mcp.resource");
-      expect(MCP_ANNOTATION_PROPS.MCP_TOOL).toBe("@mcp.tool");
-      expect(MCP_ANNOTATION_PROPS.MCP_PROMPT).toBe("@mcp.prompts");
     });
   });
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds the option to provide deeper level hints for @mcp.wrap annotations, such as `@mcp.wrap: { hint: { get: 'get hint' } }`. On top of this, the resource description also gets added to description of the wrapper's tools, such that context about the overall entity can be shared across.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [X] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## What Changed

<!-- List the main changes made -->
- Resource descriptions now also apply to the wrapped tools
- All CRUD operations within the wrapper can now have unique hints


## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Add @mcp.wrap.hint: { <operation>: 'Hint' } } to a given object along with a description for the overall resource
2. Open the MCP inspector and list out the tool.
3. Verify that the received tool description contains both the wrapper hint and the resource description

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

