### PR TITLE
fix: Array types for tools

### DIFF
--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -8,10 +8,8 @@ import {
 } from "./structures";
 import {
   AnnotatedMcpEntry,
-  CdsRestriction,
   McpAnnotationPrompt,
   McpAnnotationStructure,
-  McpAnnotationWrap,
   ParsedAnnotations,
 } from "./types";
 import {

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,4 +1,5 @@
 import { McpResourceAnnotation } from "../annotations/structures";
+import { LOGGER } from "../logger";
 import { MCP_SESSION_HEADER, NEW_LINE } from "./constants";
 import { McpSession } from "./types";
 import { Request, Response } from "express";
@@ -13,10 +14,76 @@ export function determineMcpParameterType(cdsType: string): unknown {
   switch (cdsType) {
     case "String":
       return z.string();
+    case "UUID":
+      return z.string();
+    case "Date":
+      return z.date();
+    case "Time":
+      return z.date();
+    case "DateTime":
+      return z.date();
+    case "Timestamp":
+      return z.number();
     case "Integer":
+      return z.number();
+    case "Int16":
+      return z.number();
+    case "Int32":
+      return z.number();
+    case "Int64":
+      return z.number();
+    case "UInt8":
+      return z.number();
+    case "Decimal":
+      return z.number();
+    case "Double":
       return z.number();
     case "Boolean":
       return z.boolean();
+    case "Binary":
+      return z.string();
+    case "LargeBinary":
+      return z.string();
+    case "LargeString":
+      return z.string();
+    case "Map":
+      return z.any();
+    case "StringArray":
+      return z.array(z.string());
+    case "DateArray":
+      return z.array(z.date());
+    case "TimeArray":
+      return z.array(z.date());
+    case "DateTimeArray":
+      return z.array(z.date());
+    case "TimestampArray":
+      return z.array(z.number());
+    case "UUIDArray":
+      return z.array(z.string());
+    case "IntegerArray":
+      return z.array(z.number());
+    case "Int16Array":
+      return z.array(z.number());
+    case "Int32Array":
+      return z.array(z.number());
+    case "Int64Array":
+      return z.array(z.number());
+    case "UInt8Array":
+      return z.array(z.number());
+    case "DecimalArray":
+      return z.array(z.number());
+    case "BooleanArray":
+      return z.array(z.boolean());
+    case "DoubleArray":
+      return z.array(z.number());
+    case "BinaryArray":
+      return z.array(z.string());
+    case "LargeBinaryArray":
+      return z.array(z.string());
+    case "LargeStringArray":
+      return z.array(z.string());
+    case "MapArray":
+      return z.array(z.any());
     default:
       return z.string();
   }

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -125,6 +125,13 @@ service CatalogService {
   }
   function getBookRecommendation()                              returns String;
 
+  @mcp: {
+    name       : 'get-many-authors',
+    description: 'Gets many authors. Using for testing "many"',
+    tool       : true
+  }
+  function getManyAuthors(ids : array of String)                returns many String;
+
 
   @mcp: {
     name       : 'check-author-name',

--- a/test/unit/annotations/parser.spec.ts
+++ b/test/unit/annotations/parser.spec.ts
@@ -927,6 +927,220 @@ describe("Parser", () => {
       });
     });
 
+    test("should parse function with array parameter types", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestFunction": {
+            kind: "function",
+            "@mcp.name": "Test Array Function",
+            "@mcp.description": "Test function with array parameters",
+            "@mcp.tool": true,
+            params: {
+              stringIds: {
+                items: { type: "cds.String" },
+              },
+              integerValues: {
+                items: { type: "cds.Integer" },
+              },
+              booleanFlags: {
+                items: { type: "cds.Boolean" },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("TestFunction") as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation.name).toBe("Test Array Function");
+      expect(annotation.parameters?.get("stringIds")).toBe("StringArray");
+      expect(annotation.parameters?.get("integerValues")).toBe("IntegerArray");
+      expect(annotation.parameters?.get("booleanFlags")).toBe("BooleanArray");
+    });
+
+    test("should parse action with mixed array and non-array parameters", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestAction": {
+            kind: "action",
+            "@mcp.name": "Mixed Parameters Action",
+            "@mcp.description": "Action with mixed parameter types",
+            "@mcp.tool": true,
+            params: {
+              singleValue: { type: "cds.String" },
+              arrayValues: {
+                items: { type: "cds.String" },
+              },
+              numericValue: { type: "cds.Integer" },
+              numericArray: {
+                items: { type: "cds.Integer" },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("TestAction") as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation.parameters?.get("singleValue")).toBe("String");
+      expect(annotation.parameters?.get("arrayValues")).toBe("StringArray");
+      expect(annotation.parameters?.get("numericValue")).toBe("Integer");
+      expect(annotation.parameters?.get("numericArray")).toBe("IntegerArray");
+    });
+
+    test("should parse function with array of complex types", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "myTypes.Person": {
+            kind: "type",
+            elements: {
+              name: { type: "cds.String" },
+              age: { type: "cds.Integer" },
+            },
+          },
+          "TestService.TestFunction": {
+            kind: "function",
+            "@mcp.name": "Complex Array Function",
+            "@mcp.description": "Function with array of complex types",
+            "@mcp.tool": true,
+            params: {
+              personNames: {
+                items: {
+                  type: { ref: ["myTypes.Person", "name"] },
+                },
+              },
+              personAges: {
+                items: {
+                  type: { ref: ["myTypes.Person", "age"] },
+                },
+              },
+              simpleArray: {
+                items: { type: "cds.UUID" },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("TestFunction") as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation.parameters?.get("personNames")).toBe("StringArray");
+      expect(annotation.parameters?.get("personAges")).toBe("IntegerArray");
+      expect(annotation.parameters?.get("simpleArray")).toBe("UUIDArray");
+    });
+
+    test("should parse bound operation with array parameters", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.TestEntity": {
+            kind: "entity",
+            elements: {
+              id: { type: "cds.UUID", key: true },
+            },
+            actions: {
+              processItems: {
+                kind: "action",
+                "@mcp.name": "Process Items",
+                "@mcp.description": "Bound action with array parameters",
+                "@mcp.tool": true,
+                params: {
+                  itemIds: {
+                    items: { type: "cds.UUID" },
+                  },
+                  quantities: {
+                    items: { type: "cds.Integer" },
+                  },
+                  enabled: { type: "cds.Boolean" },
+                },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("processItems") as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation.name).toBe("Process Items");
+      expect(annotation.parameters?.get("itemIds")).toBe("UUIDArray");
+      expect(annotation.parameters?.get("quantities")).toBe("IntegerArray");
+      expect(annotation.parameters?.get("enabled")).toBe("Boolean");
+    });
+
+    test("should handle all supported array types correctly", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.AllArrayTypesFunction": {
+            kind: "function",
+            "@mcp.name": "All Array Types",
+            "@mcp.description": "Function testing all array types",
+            "@mcp.tool": true,
+            params: {
+              uuids: { items: { type: "cds.UUID" } },
+              strings: { items: { type: "cds.String" } },
+              integers: { items: { type: "cds.Integer" } },
+              int16s: { items: { type: "cds.Int16" } },
+              int32s: { items: { type: "cds.Int32" } },
+              int64s: { items: { type: "cds.Int64" } },
+              uint8s: { items: { type: "cds.UInt8" } },
+              decimals: { items: { type: "cds.Decimal" } },
+              doubles: { items: { type: "cds.Double" } },
+              booleans: { items: { type: "cds.Boolean" } },
+              dates: { items: { type: "cds.Date" } },
+              times: { items: { type: "cds.Time" } },
+              datetimes: { items: { type: "cds.DateTime" } },
+              timestamps: { items: { type: "cds.Timestamp" } },
+              binaries: { items: { type: "cds.Binary" } },
+              largeBinaries: { items: { type: "cds.LargeBinary" } },
+              largeStrings: { items: { type: "cds.LargeString" } },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get(
+        "AllArrayTypesFunction",
+      ) as McpToolAnnotation;
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+
+      // Verify all array types are properly mapped with "Array" suffix
+      expect(annotation.parameters?.get("uuids")).toBe("UUIDArray");
+      expect(annotation.parameters?.get("strings")).toBe("StringArray");
+      expect(annotation.parameters?.get("integers")).toBe("IntegerArray");
+      expect(annotation.parameters?.get("int16s")).toBe("Int16Array");
+      expect(annotation.parameters?.get("int32s")).toBe("Int32Array");
+      expect(annotation.parameters?.get("int64s")).toBe("Int64Array");
+      expect(annotation.parameters?.get("uint8s")).toBe("UInt8Array");
+      expect(annotation.parameters?.get("decimals")).toBe("DecimalArray");
+      expect(annotation.parameters?.get("doubles")).toBe("DoubleArray");
+      expect(annotation.parameters?.get("booleans")).toBe("BooleanArray");
+      expect(annotation.parameters?.get("dates")).toBe("DateArray");
+      expect(annotation.parameters?.get("times")).toBe("TimeArray");
+      expect(annotation.parameters?.get("datetimes")).toBe("DateTimeArray");
+      expect(annotation.parameters?.get("timestamps")).toBe("TimestampArray");
+      expect(annotation.parameters?.get("binaries")).toBe("BinaryArray");
+      expect(annotation.parameters?.get("largeBinaries")).toBe(
+        "LargeBinaryArray",
+      );
+      expect(annotation.parameters?.get("largeStrings")).toBe(
+        "LargeStringArray",
+      );
+    });
+
     test("should handle empty detailed hint object", () => {
       const model: csn.CSN = {
         definitions: {

--- a/test/unit/annotations/utils.spec.ts
+++ b/test/unit/annotations/utils.spec.ts
@@ -396,6 +396,159 @@ describe("Utils", () => {
       expect(result.operationKind).toBe("function");
     });
 
+    test("should parse array parameters correctly", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "function",
+          params: {
+            stringArray: {
+              items: { type: "cds.String" },
+            },
+            integerArray: {
+              items: { type: "cds.Integer" },
+            },
+            booleanArray: {
+              items: { type: "cds.Boolean" },
+            },
+            uuidArray: {
+              items: { type: "cds.UUID" },
+            },
+          },
+        } as any,
+        name: "test-array",
+        description: "test array parameters",
+      };
+
+      const mockModel: csn.CSN = {
+        definitions: {},
+      };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.size).toBe(4);
+      expect(result.parameters!.get("stringArray")).toBe("StringArray");
+      expect(result.parameters!.get("integerArray")).toBe("IntegerArray");
+      expect(result.parameters!.get("booleanArray")).toBe("BooleanArray");
+      expect(result.parameters!.get("uuidArray")).toBe("UUIDArray");
+      expect(result.operationKind).toBe("function");
+    });
+
+    test("should parse mixed array and non-array parameters", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "action",
+          params: {
+            singleString: { type: "cds.String" },
+            stringArray: {
+              items: { type: "cds.String" },
+            },
+            singleInteger: { type: "cds.Integer" },
+            integerArray: {
+              items: { type: "cds.Integer" },
+            },
+          },
+        } as any,
+        name: "test-mixed",
+        description: "test mixed parameters",
+      };
+
+      const mockModel: csn.CSN = {
+        definitions: {},
+      };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.size).toBe(4);
+      expect(result.parameters!.get("singleString")).toBe("String");
+      expect(result.parameters!.get("stringArray")).toBe("StringArray");
+      expect(result.parameters!.get("singleInteger")).toBe("Integer");
+      expect(result.parameters!.get("integerArray")).toBe("IntegerArray");
+      expect(result.operationKind).toBe("action");
+    });
+
+    test("should parse array of complex types", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "function",
+          params: {
+            complexArray: {
+              items: {
+                type: { ref: ["myTypes.Person", "name"] },
+              },
+            },
+          },
+        } as any,
+        name: "test-complex-array",
+        description: "test complex array parameters",
+      };
+
+      const mockModel: csn.CSN = {
+        definitions: {
+          "myTypes.Person": {
+            kind: "type",
+            elements: {
+              name: { type: "cds.String" } as any,
+            },
+          } as any,
+        },
+      };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.size).toBe(1);
+      expect(result.parameters!.get("complexArray")).toBe("StringArray");
+    });
+
+    test("should handle all CDS array types correctly", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "function",
+          params: {
+            dateArray: { items: { type: "cds.Date" } },
+            timeArray: { items: { type: "cds.Time" } },
+            datetimeArray: { items: { type: "cds.DateTime" } },
+            timestampArray: { items: { type: "cds.Timestamp" } },
+            decimalArray: { items: { type: "cds.Decimal" } },
+            doubleArray: { items: { type: "cds.Double" } },
+            int16Array: { items: { type: "cds.Int16" } },
+            int32Array: { items: { type: "cds.Int32" } },
+            int64Array: { items: { type: "cds.Int64" } },
+            uint8Array: { items: { type: "cds.UInt8" } },
+            binaryArray: { items: { type: "cds.Binary" } },
+            largeBinaryArray: { items: { type: "cds.LargeBinary" } },
+            largeStringArray: { items: { type: "cds.LargeString" } },
+          },
+        } as any,
+        name: "test-all-arrays",
+        description: "test all array types",
+      };
+
+      const mockModel: csn.CSN = {
+        definitions: {},
+      };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.size).toBe(13);
+      expect(result.parameters!.get("dateArray")).toBe("DateArray");
+      expect(result.parameters!.get("timeArray")).toBe("TimeArray");
+      expect(result.parameters!.get("datetimeArray")).toBe("DateTimeArray");
+      expect(result.parameters!.get("timestampArray")).toBe("TimestampArray");
+      expect(result.parameters!.get("decimalArray")).toBe("DecimalArray");
+      expect(result.parameters!.get("doubleArray")).toBe("DoubleArray");
+      expect(result.parameters!.get("int16Array")).toBe("Int16Array");
+      expect(result.parameters!.get("int32Array")).toBe("Int32Array");
+      expect(result.parameters!.get("int64Array")).toBe("Int64Array");
+      expect(result.parameters!.get("uint8Array")).toBe("UInt8Array");
+      expect(result.parameters!.get("binaryArray")).toBe("BinaryArray");
+      expect(result.parameters!.get("largeBinaryArray")).toBe(
+        "LargeBinaryArray",
+      );
+      expect(result.parameters!.get("largeStringArray")).toBe(
+        "LargeStringArray",
+      );
+    });
+
     test("should handle operation without parameters", () => {
       const annotations: McpAnnotationStructure = {
         definition: {

--- a/test/unit/mcp/utils.spec.ts
+++ b/test/unit/mcp/utils.spec.ts
@@ -14,6 +14,9 @@ jest.mock("zod", () => ({
     string: jest.fn(() => "string-type"),
     number: jest.fn(() => "number-type"),
     boolean: jest.fn(() => "boolean-type"),
+    date: jest.fn(() => "date-type"),
+    array: jest.fn((itemType: any) => `array-of-${itemType}`),
+    any: jest.fn(() => "any-type"),
   },
 }));
 
@@ -29,16 +32,99 @@ describe("Server Utils", () => {
       expect(result).toBe("string-type");
     });
 
-    test("should return number type for Integer CDS type", () => {
-      const result = determineMcpParameterType("Integer");
+    test("should return string type for UUID CDS type", () => {
+      const result = determineMcpParameterType("UUID");
+      expect(z.string).toHaveBeenCalled();
+      expect(result).toBe("string-type");
+    });
+
+    test("should return date type for Date CDS types", () => {
+      const dateTypes = ["Date", "Time", "DateTime"];
+
+      dateTypes.forEach((type) => {
+        const result = determineMcpParameterType(type);
+        expect(result).toBe("date-type");
+      });
+
+      expect(z.date).toHaveBeenCalledTimes(dateTypes.length);
+    });
+
+    test("should return number type for Timestamp CDS type", () => {
+      const result = determineMcpParameterType("Timestamp");
       expect(z.number).toHaveBeenCalled();
       expect(result).toBe("number-type");
+    });
+
+    test("should return number type for Integer CDS types", () => {
+      const numberTypes = [
+        "Integer",
+        "Int16",
+        "Int32",
+        "Int64",
+        "UInt8",
+        "Decimal",
+        "Double",
+      ];
+
+      numberTypes.forEach((type) => {
+        const result = determineMcpParameterType(type);
+        expect(result).toBe("number-type");
+      });
+
+      expect(z.number).toHaveBeenCalledTimes(numberTypes.length);
     });
 
     test("should return boolean type for Boolean CDS type", () => {
       const result = determineMcpParameterType("Boolean");
       expect(z.boolean).toHaveBeenCalled();
       expect(result).toBe("boolean-type");
+    });
+
+    test("should return string type for Binary CDS types", () => {
+      const binaryTypes = ["Binary", "LargeBinary", "LargeString"];
+
+      binaryTypes.forEach((type) => {
+        const result = determineMcpParameterType(type);
+        expect(result).toBe("string-type");
+      });
+
+      expect(z.string).toHaveBeenCalledTimes(binaryTypes.length);
+    });
+
+    test("should return any type for Map CDS type", () => {
+      const result = determineMcpParameterType("Map");
+      expect(z.any).toHaveBeenCalled();
+      expect(result).toBe("any-type");
+    });
+
+    test("should return array types for Array CDS types", () => {
+      const arrayTypes = [
+        "StringArray",
+        "DateArray",
+        "TimeArray",
+        "DateTimeArray",
+        "TimestampArray",
+        "UUIDArray",
+        "IntegerArray",
+        "Int16Array",
+        "Int32Array",
+        "Int64Array",
+        "UInt8Array",
+        "DecimalArray",
+        "BooleanArray",
+        "DoubleArray",
+        "BinaryArray",
+        "LargeBinaryArray",
+        "LargeStringArray",
+        "MapArray",
+      ];
+
+      arrayTypes.forEach((type) => {
+        const result = determineMcpParameterType(type);
+        expect(result).toMatch(/^array-of-/);
+      });
+
+      expect(z.array).toHaveBeenCalledTimes(arrayTypes.length);
     });
 
     test("should default to string type for unknown CDS type", () => {
@@ -72,15 +158,6 @@ describe("Server Utils", () => {
       expect(z.string).toHaveBeenCalledTimes(2);
       expect(resultLower).toBe("string-type");
       expect(resultUpper).toBe("string-type");
-    });
-
-    test("should handle special CDS types", () => {
-      const stringTypes = ["UUID", "DateTime", "Decimal", "Double"];
-
-      stringTypes.forEach((type) => {
-        const result = determineMcpParameterType(type);
-        expect(result).toBe("string-type");
-      });
     });
   });
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds fix for the parsing of 'array of' and 'many' parameters for operations. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes https://github.com/gavdilabs/cap-mcp-plugin/issues/44

## What Changed

<!-- List the main changes made -->
- Added parser logic for CSN items definition

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Create operation with many/array parameters
2. Run MCP plugin and observe the parser


## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

