### PR TITLE
fix: array elements on resources

### DIFF
--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -71,6 +71,7 @@ export function parseDefinitions(model: csn.CSN): ParsedAnnotations {
           target,
           verifiedAnnotations,
           def,
+          model,
         );
         if (!resourceAnnotation) continue;
         result.set(resourceAnnotation.target, resourceAnnotation);
@@ -184,11 +185,12 @@ function constructResourceAnnotation(
   target: string,
   annotations: McpAnnotationStructure,
   definition: csn.Definition,
+  model: csn.CSN,
 ): McpResourceAnnotation | undefined {
   if (!isValidResourceAnnotation(annotations)) return undefined;
 
   const functionalities = determineResourceOptions(annotations);
-  const { properties, resourceKeys } = parseResourceElements(definition);
+  const { properties, resourceKeys } = parseResourceElements(definition, model);
   const restrictions = parseCdsRestrictions(
     annotations.restrict,
     annotations.requires,

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -45,6 +45,10 @@ service CatalogService {
   }
   entity Authors          as projection on my.Authors;
 
+  extend my.Authors with {
+    nominations : array of String;
+  };
+
   annotate CatalogService.Authors with @mcp.wrap: {
     tools: true,
     modes: [


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds fix for the cases where resources, i.e. entities, have array typed properties on the model. 
Instead of only parsing first level properties, the parser now follows the same process as the tools parsing process. 

This not only fixes the array types but also accounts for nested types in resource models. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to https://github.com/gavdilabs/cap-mcp-plugin/issues/44

## What Changed

<!-- List the main changes made -->
- Updated resource parser to follow same process as tools parser

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Add property with array type to an entity (or use the demo project where author has nominations prop) 
2. Test through the inspector that all properties expected shows up

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

