### PR TITLE
chore: add author attribution to changelog entries

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -37,7 +37,8 @@
             "section": "Additional Changes"
           }
         ]
-      }
+      },
+      "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{subject}}{{#if hash}} ([{{hash}}]({{repository}}/commit/{{hash}})){{/if}}{{#if references~}}{{~#each references}}, closes [{{#if owner}}{{owner}}/{{repository}}{{else}}{{../repository}}{{/if}}#{{issue}}]({{../host}}/{{#if owner}}{{owner}}/{{repository}}{{else}}{{../owner}}/{{../repository}}{{/if}}/issues/{{issue}}){{/each}}{{/if}}{{#if author}} - by @{{author}}{{/if}}"
     }
   }
 }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
This change updates the release-it configuration to include author names in the changelog entries with the format `- by @Author`.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [X] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## What Changed

<!-- List the main changes made -->
- release-it now includes the author in the changelog 

---

