### PR TITLE
fix: composition zod type

### DIFF
--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -517,7 +517,13 @@ function registerCreateTool(
         .optional();
       continue;
     }
-    inputSchema[propName] = (determineMcpParameterType(cdsType) as z.ZodType)
+    inputSchema[propName] = (
+      determineMcpParameterType(
+        cdsType,
+        propName,
+        `${resAnno.serviceName}.${resAnno.target}`,
+      ) as z.ZodType
+    )
       .optional()
       .describe(`Field ${propName}`);
   }
@@ -623,7 +629,13 @@ function registerUpdateTool(
         .optional();
       continue;
     }
-    inputSchema[propName] = (determineMcpParameterType(cdsType) as z.ZodType)
+    inputSchema[propName] = (
+      determineMcpParameterType(
+        cdsType,
+        propName,
+        `${resAnno.serviceName}.${resAnno.target}`,
+      ) as z.ZodType
+    )
       .optional()
       .describe(`Field ${propName}`);
   }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Implements an additional parsing option for the 'cds.Composition' type which takes into account the structure of the composition object.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes https://github.com/gavdilabs/cap-mcp-plugin/issues/47

## What Changed

<!-- List the main changes made -->
- Added complex parsing for resource tool wrappers that contain Composition objects or arrays

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Create entity with Composition and mark it as an MCP resource with tool wrappers
2. Open the inspector and verify that it can understand both Composition and Composition of many 

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

