### PR TITLE
fix: Multi-key associations and related types

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -12,8 +12,8 @@ cds.on("bootstrap", async (app) => {
   await plugin?.onBootstrap(app);
 });
 
-cds.on("loaded", async (model) => {
-  await plugin?.onLoaded(model);
+cds.on("serving", async () => {
+  await plugin?.onLoaded(cds.model);
 });
 
 cds.on("shutdown", async () => {

--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -190,6 +190,14 @@ function constructResourceAnnotation(
   if (!isValidResourceAnnotation(annotations)) return undefined;
 
   const functionalities = determineResourceOptions(annotations);
+  const foreignKeys = new Map<string, string>(
+    Object.entries(
+      model.definitions?.[`${serviceName}.${target}`].elements ?? {},
+    )
+      .filter(([_, v]) => (v as any)["@odata.foreignKey4"] !== undefined)
+      .map(([k, v]) => [k, (v as any)["@odata.foreignKey4"]]),
+  );
+
   const { properties, resourceKeys } = parseResourceElements(definition, model);
   const restrictions = parseCdsRestrictions(
     annotations.restrict,
@@ -204,6 +212,7 @@ function constructResourceAnnotation(
     functionalities,
     properties,
     resourceKeys,
+    foreignKeys,
     annotations.wrap,
     restrictions,
   );

--- a/src/annotations/structures.ts
+++ b/src/annotations/structures.ts
@@ -99,6 +99,8 @@ export class McpResourceAnnotation extends McpAnnotation {
   private readonly _resourceKeys: Map<string, string>;
   /** Optional wrapper configuration to expose this resource as tools */
   private readonly _wrap?: McpAnnotationWrap;
+  /** Map of foreign keys property -> associated entity */
+  private readonly _foreignKeys: Map<string, string>;
 
   /**
    * Creates a new MCP resource annotation
@@ -109,6 +111,8 @@ export class McpResourceAnnotation extends McpAnnotation {
    * @param functionalities - Set of enabled OData query options (filter, top, skip, etc.)
    * @param properties - Map of entity properties to their CDS types
    * @param resourceKeys - Map of key fields to their types
+   * @param foreignKeys - Map of foreign keys used by entity
+   * @param wrap - Wrap usage
    * @param restrictions - Optional restrictions based on CDS roles
    */
   constructor(
@@ -119,6 +123,7 @@ export class McpResourceAnnotation extends McpAnnotation {
     functionalities: Set<McpResourceOption>,
     properties: Map<string, string>,
     resourceKeys: Map<string, string>,
+    foreignKeys: Map<string, string>,
     wrap?: McpAnnotationWrap,
     restrictions?: McpRestriction[],
   ) {
@@ -127,6 +132,7 @@ export class McpResourceAnnotation extends McpAnnotation {
     this._properties = properties;
     this._resourceKeys = resourceKeys;
     this._wrap = wrap;
+    this._foreignKeys = foreignKeys;
   }
 
   /**
@@ -135,6 +141,14 @@ export class McpResourceAnnotation extends McpAnnotation {
    */
   get functionalities(): Set<McpResourceOption> {
     return this._functionalities;
+  }
+
+  /**
+   * Gets the map of foreign keys used withing the resource
+   * @returns Map of foreign keys - property name -> associated entity
+   */
+  get foreignKeys(): Map<string, string> {
+    return this._foreignKeys;
   }
 
   /**

--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -249,18 +249,9 @@ export function parseResourceElements(
 
     const result = parseParam(k, v);
 
-    if (!v.key) continue;
+    if (!v.key || v.type === "cds.Association") continue;
     resourceKeys.set(k, result);
   }
-
-  // for (const [key, value] of Object.entries(definition.elements || {})) {
-  //   if (!value.type) continue;
-  //   const parsedType = value.type.replace("cds.", "");
-  //   properties.set(key, parsedType);
-  //
-  //   if (!value.key) continue;
-  //   resourceKeys.set(key, parsedType);
-  // }
 
   return {
     properties,

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -5,7 +5,8 @@ import { getAccessRights, WrapAccess } from "../auth/utils";
 import { LOGGER } from "../logger";
 import { determineMcpParameterType, toolError, asMcpResult } from "./utils";
 import { EntityOperationMode, EntityListQueryArgs } from "./types";
-import type { ql, Service } from "@sap/cds";
+import type { csn, ql, Service } from "@sap/cds";
+import cds from "@sap/cds";
 
 /**
  * Wraps a promise with a timeout to avoid indefinite hangs in MCP tool calls.
@@ -107,23 +108,6 @@ function buildEnhancedQueryDescription(resAnno: McpResourceAnnotation): string {
 }
 
 /**
- * Builds field documentation for schema descriptions
- */
-function buildFieldDocumentation(resAnno: McpResourceAnnotation): string {
-  const docs: string[] = [];
-  for (const [propName, cdsType] of resAnno.properties.entries()) {
-    const isAssociation = String(cdsType).toLowerCase().includes("association");
-    if (isAssociation) {
-      docs.push(`${propName}(association: compare by key value)`);
-      docs.push(`${propName}_ID(foreign key for ${propName})`);
-    } else {
-      docs.push(`${propName}(${String(cdsType).toLowerCase()})`);
-    }
-  }
-  return docs.join(", ");
-}
-
-/**
  * Registers CRUD-like MCP tools for an annotated entity (resource).
  * Modes can be controlled globally via configuration and per-entity via @mcp.wrap.
  *
@@ -210,14 +194,6 @@ function registerQueryTool(
       ([, cdsType]) => !String(cdsType).toLowerCase().includes("association"),
     )
     .map(([name]) => name);
-
-  // Add foreign key fields for associations to scalar keys for select/orderby
-  for (const [propName, cdsType] of resAnno.properties.entries()) {
-    const isAssociation = String(cdsType).toLowerCase().includes("association");
-    if (isAssociation) {
-      scalarKeys.push(`${propName}_ID`);
-    }
-  }
 
   // Build where field enum: use same fields as select (scalar + foreign keys)
   // This ensures consistency - what you can select, you can filter by
@@ -510,13 +486,10 @@ function registerCreateTool(
   for (const [propName, cdsType] of resAnno.properties.entries()) {
     const isAssociation = String(cdsType).toLowerCase().includes("association");
     if (isAssociation) {
-      // Prefer foreign key input for associations: <assoc>_ID
-      inputSchema[`${propName}_ID`] = z
-        .number()
-        .describe(`Foreign key for association ${propName}`)
-        .optional();
+      // Association keys are supplied directly from model loading as of v1.1.2
       continue;
     }
+
     inputSchema[propName] = (
       determineMcpParameterType(
         cdsType,
@@ -623,10 +596,7 @@ function registerUpdateTool(
     if (resAnno.resourceKeys.has(propName)) continue;
     const isAssociation = String(cdsType).toLowerCase().includes("association");
     if (isAssociation) {
-      inputSchema[`${propName}_ID`] = z
-        .number()
-        .describe(`Foreign key for association ${propName}`)
-        .optional();
+      // Association keys are supplied directly from model loading as of v1.1.2
       continue;
     }
     inputSchema[propName] = (

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -498,7 +498,11 @@ function registerCreateTool(
       ) as z.ZodType
     )
       .optional()
-      .describe(`Field ${propName}`);
+      .describe(
+        resAnno.foreignKeys.has(propName)
+          ? `Foreign key to ${resAnno.foreignKeys.get(propName)} on ${propName}`
+          : `Field ${propName}`,
+      );
   }
 
   const hint = constructHintMessage(resAnno, "create");
@@ -607,7 +611,11 @@ function registerUpdateTool(
       ) as z.ZodType
     )
       .optional()
-      .describe(`Field ${propName}`);
+      .describe(
+        resAnno.foreignKeys.has(propName)
+          ? `Foreign key to ${resAnno.foreignKeys.get(propName)} on ${propName}`
+          : `Field ${propName}`,
+      );
   }
 
   const keyList = Array.from(resAnno.resourceKeys.keys()).join(", ");

--- a/test/integration/fixtures/test-server.ts
+++ b/test/integration/fixtures/test-server.ts
@@ -87,7 +87,7 @@ export class TestMcpServer {
   /**
    * Creates a test CSN model with MCP annotations
    */
-  private createTestModel(): csn.CSN {
+  protected createTestModel(): csn.CSN {
     return {
       definitions: {
         TestService: {

--- a/test/integration/http-api/mcp-complex-keys.spec.ts
+++ b/test/integration/http-api/mcp-complex-keys.spec.ts
@@ -1,0 +1,254 @@
+import request from "supertest";
+import { TestMcpServer } from "../fixtures/test-server";
+
+describe("MCP HTTP API - Complex Keys Integration", () => {
+  let testServer: TestMcpServer;
+  let app: any;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    testServer = new TestMcpServer();
+    await testServer.setup();
+    app = testServer.getApp();
+
+    // Initialize session
+    const initResponse = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: { tools: {}, resources: {} },
+          clientInfo: { name: "test", version: "1.0.0" },
+        },
+      });
+
+    sessionId = initResponse.headers["mcp-session-id"];
+  });
+
+  afterEach(async () => {
+    await testServer.stop();
+  });
+
+  describe("Backward Compatibility with Simple Keys", () => {
+    it("should work with existing simple key entities", async () => {
+      const toolsResponse = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
+        .expect(200);
+
+      const tools = toolsResponse.body?.result?.tools || [];
+      const toolNames = tools.map((t: any) => t.name);
+
+      // Should have tools for the simple Books entity from TestMcpServer
+      expect(toolNames).toEqual(
+        expect.arrayContaining([
+          "TestService_Books_query",
+          "TestService_Books_get",
+          "TestService_Books_create",
+          "TestService_Books_update",
+          "TestService_Books_delete",
+        ]),
+      );
+
+      // Get tool for Books should have simple integer key
+      const getBooksSchema = tools.find(
+        (t: any) => t.name === "TestService_Books_get",
+      )?.inputSchema;
+
+      expect(getBooksSchema.properties).toHaveProperty("ID");
+      expect(getBooksSchema.required).toContain("ID");
+      expect(getBooksSchema.properties.ID.type).toBe("number");
+
+      // Verify get tool for simple entity works
+      const getBooksResponse = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_get",
+            arguments: {
+              ID: 1, // Simple integer key
+            },
+          },
+        });
+
+      expect(getBooksResponse.status).toBe(200);
+      expect(getBooksResponse.body).toHaveProperty("result");
+    });
+
+    it("should handle tools with missing keys appropriately", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_get",
+            arguments: {
+              // Missing required ID key
+            },
+          },
+        });
+
+      // Should return validation error
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("error");
+      expect(response.body.error.message).toContain("invalid_type");
+    });
+
+    it("should validate parameter types correctly", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_get",
+            arguments: {
+              ID: "not-a-number", // Invalid type - should be integer
+            },
+          },
+        });
+
+      // Should return validation error for type mismatch
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("error");
+      expect(response.body.error.message).toContain("invalid_type");
+    });
+
+    it("should handle entity operations for simple key entities", async () => {
+      // Test query operation
+      const queryResponse = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 4,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_query",
+            arguments: {
+              where: [
+                {
+                  field: "title",
+                  op: "contains",
+                  value: "Test",
+                },
+              ],
+              top: 10,
+            },
+          },
+        });
+
+      expect(queryResponse.status).toBe(200);
+      expect(queryResponse.body).toHaveProperty("result");
+
+      // Test create operation
+      const createResponse = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_create",
+            arguments: {
+              title: "Test Book",
+              author: "Test Author",
+              price: 29.99,
+              stock: 10,
+            },
+          },
+        });
+
+      expect(createResponse.status).toBe(200);
+      expect(createResponse.body).toHaveProperty("result");
+    });
+  });
+
+  describe("Complex Key Understanding", () => {
+    it("demonstrates expected foreign key naming for associations", async () => {
+      // This test documents the expected behavior for complex keys
+      // based on user's example and CAP conventions
+
+      // Given a CDS model like:
+      // entity Other { key ID: UUID; }
+      // entity Invoices {
+      //   key ID: UUID;
+      //   key random: Integer;
+      //   key other: Association to Other;
+      // }
+      // entity InvoiceLines {
+      //   key ID: UUID;
+      //   toInvoice: Association to Invoices;
+      // }
+
+      // The expected foreign key naming would be:
+      const expectedInvoicesKeys = ["ID", "random", "other_ID"];
+      const expectedInvoiceLinesKeys = ["ID"];
+      const expectedInvoiceLinesForeignKeys = [
+        "toInvoice_ID",
+        "toInvoice_random",
+        "toInvoice_other_ID",
+      ];
+
+      // This test serves as documentation of the expected behavior
+      // The actual implementation would generate tools with these key schemas
+      expect(expectedInvoicesKeys).toHaveLength(3);
+      expect(expectedInvoiceLinesKeys).toHaveLength(1);
+      expect(expectedInvoiceLinesForeignKeys).toHaveLength(3);
+
+      // Association 'other' becomes foreign key 'other_ID'
+      expect(expectedInvoicesKeys).toContain("other_ID");
+
+      // Association to complex key entity creates multiple foreign keys
+      expect(expectedInvoiceLinesForeignKeys).toContain("toInvoice_ID");
+      expect(expectedInvoiceLinesForeignKeys).toContain("toInvoice_random");
+      expect(expectedInvoiceLinesForeignKeys).toContain("toInvoice_other_ID");
+    });
+
+    it("documents complex key type resolution", async () => {
+      // This test documents how association key types should be resolved
+
+      // Given:
+      // entity Other { key ID: UUID; }
+      // entity Invoices { key other: Association to Other; }
+
+      // Expected behavior:
+      const associationKeyTypeResolution = {
+        other: "Association to Other", // In CDS model
+        other_ID: "UUID", // In generated tool schema (resolved from Other.ID type)
+      };
+
+      // The fix implemented should ensure that association keys
+      // are resolved to their target entity's key types at annotation parsing time
+      expect(associationKeyTypeResolution["other_ID"]).toBe("UUID");
+    });
+  });
+});

--- a/test/unit/annotations/complex-keys.spec.ts
+++ b/test/unit/annotations/complex-keys.spec.ts
@@ -1,0 +1,487 @@
+import { parseDefinitions } from "../../../src/annotations/parser";
+import { csn } from "@sap/cds";
+import {
+  McpResourceAnnotation,
+  McpToolAnnotation,
+} from "../../../src/annotations/structures";
+
+// Mock logger
+jest.mock("../../../src/logger", () => ({
+  LOGGER: {
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("Complex Keys Annotation Parser", () => {
+  describe("parseDefinitions with complex key structures", () => {
+    test("should parse entity with multiple primitive keys", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.MultiKeyEntity": {
+            kind: "entity",
+            "@mcp.name": "Multi Key Entity",
+            "@mcp.description": "Entity with multiple primitive keys",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              random: { type: "cds.Integer", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("MultiKeyEntity");
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation!.name).toBe("Multi Key Entity");
+      expect(annotation!.serviceName).toBe("TestService");
+    });
+
+    test("should parse entity with association key", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Other": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.EntityWithAssociationKey": {
+            kind: "entity",
+            "@mcp.name": "Entity With Association Key",
+            "@mcp.description": "Entity with association as key",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              other: {
+                type: "cds.Association",
+                target: "TestService.Other",
+                key: true,
+                keys: [{ ref: ["ID"] }],
+              },
+              description: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("EntityWithAssociationKey");
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation!.name).toBe("Entity With Association Key");
+    });
+
+    test("should parse entity with mixed key types (primitives and associations)", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Other": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.ComplexKeyEntity": {
+            kind: "entity",
+            "@mcp.name": "Complex Key Entity",
+            "@mcp.description": "Entity with mixed key types",
+            "@mcp.resource": true,
+            "@mcp.wrap": {
+              tools: true,
+              modes: ["query", "get", "create", "update", "delete"],
+            },
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              random: { type: "cds.Integer", key: true },
+              other: {
+                type: "cds.Association",
+                target: "TestService.Other",
+                key: true,
+                keys: [{ ref: ["ID"] }],
+              },
+              date: { type: "cds.Date" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get(
+        "ComplexKeyEntity",
+      ) as McpResourceAnnotation;
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation.name).toBe("Complex Key Entity");
+      expect(annotation.wrap?.tools).toBe(true);
+      expect(annotation.wrap?.modes).toEqual([
+        "query",
+        "get",
+        "create",
+        "update",
+        "delete",
+      ]);
+    });
+
+    test("should parse entity with composition relationship", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Invoices": {
+            kind: "entity",
+            "@mcp.name": "Invoices",
+            "@mcp.description": "Invoice entity with composition",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              random: { type: "cds.Integer", key: true },
+              date: { type: "cds.Date" },
+              lineItems: {
+                type: "cds.Composition",
+                cardinality: { max: "*" },
+                target: "TestService.InvoiceLines",
+                on: [
+                  { ref: ["lineItems", "toInvoice"] },
+                  "=",
+                  { ref: ["$self"] },
+                ],
+              },
+            },
+          },
+          "TestService.InvoiceLines": {
+            kind: "entity",
+            "@mcp.name": "Invoice Lines",
+            "@mcp.description": "Invoice line items",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              toInvoice: {
+                type: "cds.Association",
+                target: "TestService.Invoices",
+              },
+              product: { type: "cds.String" },
+              quantity: { type: "cds.Integer" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(2);
+
+      const invoicesAnnotation = result.get("Invoices");
+      expect(invoicesAnnotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(invoicesAnnotation!.name).toBe("Invoices");
+
+      const linesAnnotation = result.get("InvoiceLines");
+      expect(linesAnnotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(linesAnnotation!.name).toBe("Invoice Lines");
+    });
+
+    test("should parse bound operation on entity with complex keys", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Other": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.ComplexKeyEntity": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              random: { type: "cds.Integer", key: true },
+              other: {
+                type: "cds.Association",
+                target: "TestService.Other",
+                key: true,
+                keys: [{ ref: ["ID"] }],
+              },
+              description: { type: "cds.String" },
+            },
+            actions: {
+              processComplexEntity: {
+                kind: "action",
+                "@mcp.name": "Process Complex Entity",
+                "@mcp.description": "Process entity with complex keys",
+                "@mcp.tool": true,
+                params: {
+                  amount: { type: "cds.Decimal" },
+                },
+              },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("processComplexEntity");
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation!.name).toBe("Process Complex Entity");
+
+      const toolAnnotation = annotation as McpToolAnnotation;
+      expect(toolAnnotation.parameters?.get("amount")).toBe("Decimal");
+    });
+
+    test("should handle entity with association to entity with multiple keys", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.MultiKeyTarget": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              code: { type: "cds.String", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.EntityWithComplexAssociation": {
+            kind: "entity",
+            "@mcp.name": "Entity With Complex Association",
+            "@mcp.description": "Entity with association to multi-key target",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              target: {
+                type: "cds.Association",
+                target: "TestService.MultiKeyTarget",
+                keys: [{ ref: ["ID"] }, { ref: ["code"] }],
+              },
+              value: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("EntityWithComplexAssociation");
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation!.name).toBe("Entity With Complex Association");
+    });
+
+    test("should parse function with complex entity key parameters", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Other": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.ComplexKeyFunction": {
+            kind: "function",
+            "@mcp.name": "Complex Key Function",
+            "@mcp.description": "Function working with complex key entities",
+            "@mcp.tool": true,
+            params: {
+              entityId: { type: "cds.UUID" },
+              randomKey: { type: "cds.Integer" },
+              otherRef: { type: "cds.UUID" }, // Reference to Other.ID
+              processMode: { type: "cds.String" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("ComplexKeyFunction");
+      expect(annotation).toBeInstanceOf(McpToolAnnotation);
+      expect(annotation!.name).toBe("Complex Key Function");
+
+      const toolAnnotation = annotation as McpToolAnnotation;
+      expect(toolAnnotation.parameters?.get("entityId")).toBe("UUID");
+      expect(toolAnnotation.parameters?.get("randomKey")).toBe("Integer");
+      expect(toolAnnotation.parameters?.get("otherRef")).toBe("UUID");
+      expect(toolAnnotation.parameters?.get("processMode")).toBe("String");
+    });
+
+    test("should handle deeply nested key structures", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Level1": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              name: { type: "cds.String" },
+            },
+          },
+          "TestService.Level2": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              level1: {
+                type: "cds.Association",
+                target: "TestService.Level1",
+                key: true,
+                keys: [{ ref: ["ID"] }],
+              },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.Level3": {
+            kind: "entity",
+            "@mcp.name": "Level 3 Entity",
+            "@mcp.description": "Entity with nested association keys",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              level2: {
+                type: "cds.Association",
+                target: "TestService.Level2",
+                key: true,
+                keys: [{ ref: ["ID"] }, { ref: ["level1", "ID"] }],
+              },
+              value: { type: "cds.Integer" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(1);
+      const annotation = result.get("Level3");
+      expect(annotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(annotation!.name).toBe("Level 3 Entity");
+    });
+
+    test("should handle mixed valid and invalid complex key definitions", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.ValidComplexKey": {
+            kind: "entity",
+            "@mcp.name": "Valid Complex Key",
+            "@mcp.description": "Valid entity with complex keys",
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              code: { type: "cds.String", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "TestService.InvalidComplexKey": {
+            kind: "entity",
+            "@mcp.name": "Invalid Complex Key",
+            // Missing description - should cause validation error
+            "@mcp.resource": true,
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              code: { type: "cds.String", key: true },
+            },
+          },
+        },
+      } as any;
+
+      expect(() => parseDefinitions(model)).toThrow();
+    });
+
+    test("should parse entity with wrap tools and complex keys", () => {
+      const model: csn.CSN = {
+        definitions: {
+          "TestService.Other": {
+            kind: "entity",
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              description: { type: "cds.String" },
+            },
+          },
+          "AnMCPTestService1.Invoices": {
+            kind: "entity",
+            "@mcp.name": "test case 1",
+            "@mcp.description": "test case",
+            "@mcp.resource": true,
+            "@mcp.wrap": {
+              tools: true,
+              modes: ["query", "get", "create", "update"],
+            },
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              random: { type: "cds.Integer", key: true },
+              other: {
+                type: "cds.Association",
+                target: "TestService.Other",
+                key: true,
+                keys: [{ ref: ["ID"] }],
+              },
+              date: { type: "cds.Date" },
+              lineItems: {
+                type: "cds.Composition",
+                cardinality: { max: "*" },
+                target: "AnMCPTestService1.InvoiceLines",
+                on: [
+                  { ref: ["lineItems", "toInvoice"] },
+                  "=",
+                  { ref: ["$self"] },
+                ],
+              },
+            },
+          },
+          "AnMCPTestService1.InvoiceLines": {
+            kind: "entity",
+            "@mcp.name": "test case 2",
+            "@mcp.description": "test case",
+            "@mcp.resource": true,
+            "@mcp.wrap": {
+              tools: true,
+              modes: ["query", "get", "create", "update"],
+            },
+            elements: {
+              ID: { type: "cds.UUID", key: true },
+              toInvoice: {
+                type: "cds.Association",
+                target: "AnMCPTestService1.Invoices",
+              },
+              product: { type: "cds.String" },
+              quantity: { type: "cds.Integer" },
+            },
+          },
+        },
+      } as any;
+
+      const result = parseDefinitions(model);
+
+      expect(result.size).toBe(2);
+
+      const invoicesAnnotation = result.get(
+        "Invoices",
+      ) as McpResourceAnnotation;
+      expect(invoicesAnnotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(invoicesAnnotation.name).toBe("test case 1");
+      expect(invoicesAnnotation.wrap?.tools).toBe(true);
+      expect(invoicesAnnotation.wrap?.modes).toEqual([
+        "query",
+        "get",
+        "create",
+        "update",
+      ]);
+
+      const linesAnnotation = result.get(
+        "InvoiceLines",
+      ) as McpResourceAnnotation;
+      expect(linesAnnotation).toBeInstanceOf(McpResourceAnnotation);
+      expect(linesAnnotation.name).toBe("test case 2");
+      expect(linesAnnotation.wrap?.tools).toBe(true);
+      expect(linesAnnotation.wrap?.modes).toEqual([
+        "query",
+        "get",
+        "create",
+        "update",
+      ]);
+    });
+  });
+});

--- a/test/unit/annotations/structures.spec.ts
+++ b/test/unit/annotations/structures.spec.ts
@@ -78,6 +78,7 @@ describe("McpResourceAnnotation", () => {
       functionalities,
       properties,
       resourceKeys,
+      new Map(),
     );
   });
 
@@ -100,6 +101,7 @@ describe("McpResourceAnnotation", () => {
       new Set(),
       new Map(),
       new Map(),
+      new Map(),
     );
     expect(emptyAnnotation.functionalities.size).toBe(0);
     expect(emptyAnnotation.properties.size).toBe(0);
@@ -118,6 +120,7 @@ describe("McpResourceAnnotation", () => {
       new Set(["filter"]),
       new Map([["id", "UUID"]]),
       new Map([["id", "UUID"]]),
+      new Map(),
       undefined,
       restrictions,
     );

--- a/test/unit/mcp/complex-key-tools.spec.ts
+++ b/test/unit/mcp/complex-key-tools.spec.ts
@@ -46,6 +46,7 @@ describe("Complex Key MCP Tools", () => {
           ["ID", "UUID"],
           ["random", "Integer"],
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["query", "get", "create", "update", "delete"],
@@ -94,6 +95,7 @@ describe("Complex Key MCP Tools", () => {
           ["ID", "UUID"],
           ["other", "UUID"], // Association key in resourceKeys
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["get", "update", "delete"],
@@ -150,6 +152,7 @@ describe("Complex Key MCP Tools", () => {
           ["random", "Integer"],
           ["other", "UUID"], // All three are keys
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["query", "get", "create", "update"],
@@ -204,6 +207,7 @@ describe("Complex Key MCP Tools", () => {
           ["random", "Integer"],
           ["other", "UUID"],
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["get", "delete"], // Only get and delete
@@ -254,6 +258,7 @@ describe("Complex Key MCP Tools", () => {
           ["name", "String"],
         ]),
         new Map([["ID", "UUID"]]),
+        new Map(),
         undefined, // No wrap configuration
       );
 
@@ -296,6 +301,7 @@ describe("Complex Key MCP Tools", () => {
           ["name", "String"],
         ]),
         new Map([["ID", "UUID"]]),
+        new Map(),
         {
           tools: false, // Note: registerEntityWrappers doesn't check this flag
           modes: ["query", "get"],
@@ -352,6 +358,7 @@ describe("Complex Key MCP Tools", () => {
           ["random", "Integer"],
           ["other", "UUID"],
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["query", "get", "create", "update", "delete"],
@@ -409,6 +416,7 @@ describe("Complex Key MCP Tools", () => {
           ["random", "Integer"],
           ["other", "UUID"],
         ]),
+        new Map(),
         {
           tools: true,
           modes: ["query", "get", "create", "update"],
@@ -428,6 +436,7 @@ describe("Complex Key MCP Tools", () => {
           ["quantity", "Integer"],
         ]),
         new Map([["ID", "UUID"]]), // Simple key
+        new Map(),
         {
           tools: true,
           modes: ["query", "get", "create", "update"],

--- a/test/unit/mcp/complex-key-tools.spec.ts
+++ b/test/unit/mcp/complex-key-tools.spec.ts
@@ -1,0 +1,476 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerEntityWrappers } from "../../../src/mcp/entity-tools";
+import { McpResourceAnnotation } from "../../../src/annotations/structures";
+import { WrapAccess } from "../../../src/auth/utils";
+
+// Mock logger
+jest.mock("../../../src/logger", () => ({
+  LOGGER: {
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("Complex Key MCP Tools", () => {
+  describe("registerEntityWrappers with complex key structures", () => {
+    let server: McpServer;
+    let registeredTools: string[];
+
+    beforeEach(() => {
+      server = new McpServer({ name: "test", version: "1.0.0" });
+      registeredTools = [];
+
+      // Mock registerTool to capture tool registrations
+      // @ts-ignore override registerTool to capture registrations
+      server.registerTool = (name: string, definition: any, handler: any) => {
+        registeredTools.push(name);
+        // return noop handler
+        return undefined as any;
+      };
+    });
+
+    test("should register tools for entity with multiple primitive keys", () => {
+      const annotation = new McpResourceAnnotation(
+        "MultiKeyEntity",
+        "Multi Key Entity",
+        "MultiKeyEntity",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["description", "String"],
+          ["createdAt", "DateTime"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+        ]),
+        {
+          tools: true,
+          modes: ["query", "get", "create", "update", "delete"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get", "create", "update", "delete"],
+        accesses,
+      );
+
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_MultiKeyEntity_query",
+          "TestService_MultiKeyEntity_get",
+          "TestService_MultiKeyEntity_create",
+          "TestService_MultiKeyEntity_update",
+          "TestService_MultiKeyEntity_delete",
+        ]),
+      );
+    });
+
+    test("should register tools for entity with association keys", () => {
+      const annotation = new McpResourceAnnotation(
+        "EntityWithAssociationKey",
+        "Entity With Association Key",
+        "EntityWithAssociationKey",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["other", "UUID"], // Association key resolved to UUID type
+          ["description", "String"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["other", "UUID"], // Association key in resourceKeys
+        ]),
+        {
+          tools: true,
+          modes: ["get", "update", "delete"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: false,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["get", "update", "delete"],
+        accesses,
+      );
+
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_EntityWithAssociationKey_get",
+          "TestService_EntityWithAssociationKey_update",
+          "TestService_EntityWithAssociationKey_delete",
+        ]),
+      );
+
+      // Should not register query or create tools
+      expect(registeredTools).not.toEqual(
+        expect.arrayContaining([
+          "TestService_EntityWithAssociationKey_query",
+          "TestService_EntityWithAssociationKey_create",
+        ]),
+      );
+    });
+
+    test("should register tools for entity with mixed key types", () => {
+      const annotation = new McpResourceAnnotation(
+        "ComplexKeyEntity",
+        "test case 1",
+        "ComplexKeyEntity",
+        "AnMCPTestService1",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"], // Association key resolved to UUID type
+          ["date", "Date"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"], // All three are keys
+        ]),
+        {
+          tools: true,
+          modes: ["query", "get", "create", "update"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: false,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get", "create", "update"],
+        accesses,
+      );
+
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "AnMCPTestService1_ComplexKeyEntity_query",
+          "AnMCPTestService1_ComplexKeyEntity_get",
+          "AnMCPTestService1_ComplexKeyEntity_create",
+          "AnMCPTestService1_ComplexKeyEntity_update",
+        ]),
+      );
+
+      // Should not register delete tool
+      expect(registeredTools).not.toEqual(
+        expect.arrayContaining(["AnMCPTestService1_ComplexKeyEntity_delete"]),
+      );
+    });
+
+    test("should respect entity-level modes for complex key entity", () => {
+      const annotation = new McpResourceAnnotation(
+        "PartialModeEntity",
+        "Partial Mode Entity",
+        "PartialModeEntity",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+          ["description", "String"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+        ]),
+        {
+          tools: true,
+          modes: ["get", "delete"], // Only get and delete
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get", "create", "update", "delete"], // Global modes
+        accesses,
+      );
+
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_PartialModeEntity_get",
+          "TestService_PartialModeEntity_delete",
+        ]),
+      );
+
+      // Should not register tools not in entity modes
+      expect(registeredTools).not.toEqual(
+        expect.arrayContaining([
+          "TestService_PartialModeEntity_query",
+          "TestService_PartialModeEntity_create",
+          "TestService_PartialModeEntity_update",
+        ]),
+      );
+    });
+
+    test("should register tools using default modes when no wrap configuration", () => {
+      const annotation = new McpResourceAnnotation(
+        "SimpleEntity",
+        "Simple Entity",
+        "SimpleEntity",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["name", "String"],
+        ]),
+        new Map([["ID", "UUID"]]),
+        undefined, // No wrap configuration
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get", "create", "update", "delete"],
+        accesses,
+      );
+
+      // Should register tools using default modes when no wrap configuration
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_SimpleEntity_query",
+          "TestService_SimpleEntity_get",
+          "TestService_SimpleEntity_create",
+          "TestService_SimpleEntity_update",
+          "TestService_SimpleEntity_delete",
+        ]),
+      );
+    });
+
+    test("should register tools based on wrap modes even when tools config exists", () => {
+      const annotation = new McpResourceAnnotation(
+        "EntityWithLimitedModes",
+        "Entity With Limited Modes",
+        "EntityWithLimitedModes",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["name", "String"],
+        ]),
+        new Map([["ID", "UUID"]]),
+        {
+          tools: false, // Note: registerEntityWrappers doesn't check this flag
+          modes: ["query", "get"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get"],
+        accesses,
+      );
+
+      // registerEntityWrappers ignores the tools flag and registers based on modes
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_EntityWithLimitedModes_query",
+          "TestService_EntityWithLimitedModes_get",
+        ]),
+      );
+
+      // Should not register create/update/delete as they're not in modes
+      expect(registeredTools).not.toEqual(
+        expect.arrayContaining([
+          "TestService_EntityWithLimitedModes_create",
+          "TestService_EntityWithLimitedModes_update",
+          "TestService_EntityWithLimitedModes_delete",
+        ]),
+      );
+    });
+
+    test("should respect access permissions for complex key entity", () => {
+      const annotation = new McpResourceAnnotation(
+        "RestrictedEntity",
+        "Restricted Entity",
+        "RestrictedEntity",
+        "TestService",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+        ]),
+        {
+          tools: true,
+          modes: ["query", "get", "create", "update", "delete"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: false, // No create permission
+        canUpdate: false, // No update permission
+        canDelete: false, // No delete permission
+      };
+
+      registerEntityWrappers(
+        annotation,
+        server,
+        false,
+        ["query", "get", "create", "update", "delete"],
+        accesses,
+      );
+
+      // Should only register read operations
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "TestService_RestrictedEntity_query",
+          "TestService_RestrictedEntity_get",
+        ]),
+      );
+
+      // Should not register write operations
+      expect(registeredTools).not.toEqual(
+        expect.arrayContaining([
+          "TestService_RestrictedEntity_create",
+          "TestService_RestrictedEntity_update",
+          "TestService_RestrictedEntity_delete",
+        ]),
+      );
+    });
+
+    test("should handle composition relationships correctly", () => {
+      const invoicesAnnotation = new McpResourceAnnotation(
+        "Invoices",
+        "test case 1",
+        "Invoices",
+        "AnMCPTestService1",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+          ["date", "Date"],
+        ]),
+        new Map([
+          ["ID", "UUID"],
+          ["random", "Integer"],
+          ["other", "UUID"],
+        ]),
+        {
+          tools: true,
+          modes: ["query", "get", "create", "update"],
+        },
+      );
+
+      const linesAnnotation = new McpResourceAnnotation(
+        "InvoiceLines",
+        "test case 2",
+        "InvoiceLines",
+        "AnMCPTestService1",
+        new Set(["filter", "orderby", "select", "top", "skip"]),
+        new Map([
+          ["ID", "UUID"],
+          ["toInvoice", "UUID"], // Association to Invoices
+          ["product", "String"],
+          ["quantity", "Integer"],
+        ]),
+        new Map([["ID", "UUID"]]), // Simple key
+        {
+          tools: true,
+          modes: ["query", "get", "create", "update"],
+        },
+      );
+
+      const accesses: WrapAccess = {
+        canRead: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      };
+
+      // Register both entities
+      registerEntityWrappers(
+        invoicesAnnotation,
+        server,
+        false,
+        ["query", "get", "create", "update"],
+        accesses,
+      );
+
+      registerEntityWrappers(
+        linesAnnotation,
+        server,
+        false,
+        ["query", "get", "create", "update"],
+        accesses,
+      );
+
+      // Should register tools for both entities
+      expect(registeredTools).toEqual(
+        expect.arrayContaining([
+          "AnMCPTestService1_Invoices_query",
+          "AnMCPTestService1_Invoices_get",
+          "AnMCPTestService1_Invoices_create",
+          "AnMCPTestService1_Invoices_update",
+          "AnMCPTestService1_InvoiceLines_query",
+          "AnMCPTestService1_InvoiceLines_get",
+          "AnMCPTestService1_InvoiceLines_create",
+          "AnMCPTestService1_InvoiceLines_update",
+        ]),
+      );
+    });
+  });
+});

--- a/test/unit/mcp/entity-tools.spec.ts
+++ b/test/unit/mcp/entity-tools.spec.ts
@@ -26,6 +26,7 @@ describe("entity-tools - registration", () => {
         ["title", "String"],
       ]),
       new Map([["ID", "Integer"]]),
+      new Map(),
       { tools: true, modes: ["query", "get", "create", "update", "delete"] },
     );
 
@@ -69,6 +70,7 @@ describe("entity-tools - registration", () => {
         ["title", "String"],
       ]),
       new Map([["ID", "Integer"]]),
+      new Map(),
       { tools: true, modes: ["delete"] },
     );
 
@@ -99,6 +101,7 @@ describe("entity-tools - registration", () => {
         ["title", "String"],
       ]),
       new Map([]), // No keys - delete should not be registered
+      new Map(),
       { tools: true, modes: ["delete"] },
     );
 

--- a/test/unit/mcp/factory.spec.ts
+++ b/test/unit/mcp/factory.spec.ts
@@ -146,6 +146,7 @@ describe("Factory", () => {
         new Set(["filter"]),
         new Map([["id", "UUID"]]),
         new Map([["id", "UUID"]]),
+        new Map(),
       );
 
       const annotations: ParsedAnnotations = new Map([
@@ -203,6 +204,7 @@ describe("Factory", () => {
         "target",
         "service",
         new Set(),
+        new Map(),
         new Map(),
         new Map(),
       );
@@ -282,6 +284,7 @@ describe("Factory", () => {
         "target1",
         "service2",
         new Set(["filter"]),
+        new Map(),
         new Map(),
         new Map(),
       );

--- a/test/unit/mcp/resources.spec.ts
+++ b/test/unit/mcp/resources.spec.ts
@@ -116,6 +116,7 @@ describe("MCP Resources", () => {
           new Set(),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         const mockService = {
@@ -165,6 +166,7 @@ describe("MCP Resources", () => {
           new Set(),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         const mockService = {
@@ -192,6 +194,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -224,6 +227,7 @@ describe("MCP Resources", () => {
           new Set(),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         const mockService = {
@@ -254,6 +258,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["filter", "select", "orderby"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -297,6 +302,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["filter", "select", "orderby"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -345,6 +351,7 @@ describe("MCP Resources", () => {
           new Set(["filter"]),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         // No service added to cds.services
@@ -366,6 +373,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["filter"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -395,6 +403,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["filter"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -429,6 +438,7 @@ describe("MCP Resources", () => {
           new Set(),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         // Act
@@ -449,6 +459,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["filter"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -482,6 +493,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(["select"]),
+          new Map(),
           new Map(),
           new Map(),
         );
@@ -521,6 +533,7 @@ describe("MCP Resources", () => {
           new Set(["filter"]),
           new Map(),
           new Map(),
+          new Map(),
         );
 
         const mockService = {
@@ -558,6 +571,7 @@ describe("MCP Resources", () => {
           "TestEntity",
           "TestService",
           new Set(),
+          new Map(),
           new Map(),
           new Map(),
         );

--- a/test/unit/mcp/utils.spec.ts
+++ b/test/unit/mcp/utils.spec.ts
@@ -730,6 +730,7 @@ describe("Server Utils", () => {
           ["count", "Integer"],
         ]),
         new Map([["id", "UUID"]]),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -756,6 +757,7 @@ describe("Server Utils", () => {
         new Set(["filter", "top"]),
         new Map([["id", "UUID"]]),
         new Map(),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -778,6 +780,7 @@ describe("Server Utils", () => {
         new Set(),
         new Map([["id", "UUID"]]),
         new Map(),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -797,6 +800,7 @@ describe("Server Utils", () => {
         "NoPropsEntity",
         "TestService",
         new Set(["filter"]),
+        new Map(),
         new Map(),
         new Map(),
       );
@@ -820,6 +824,7 @@ describe("Server Utils", () => {
           ["field1", "String"],
           ["field2", "Integer"],
         ]),
+        new Map(),
         new Map(),
       );
 
@@ -849,6 +854,7 @@ describe("Server Utils", () => {
           ["boolean_field", "Boolean"],
         ]),
         new Map(),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -868,6 +874,7 @@ describe("Server Utils", () => {
         new Set(["filter"]),
         new Map([["id", "UUID"]]),
         new Map(),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -886,6 +893,7 @@ describe("Server Utils", () => {
         new Set(["top"]),
         new Map([["id", "String"]]),
         new Map(),
+        new Map(),
       );
 
       const result = writeODataDescriptionForResource(resourceAnnotation);
@@ -903,6 +911,7 @@ describe("Server Utils", () => {
         "TestService",
         new Set(["filter", "top", "skip", "select", "orderby"]),
         new Map([["test_field", "String"]]),
+        new Map(),
         new Map(),
       );
 
@@ -930,6 +939,7 @@ describe("Server Utils", () => {
           ],
           ["another_extremely_long_field_name", "AnotherCustomType"],
         ]),
+        new Map(),
         new Map(),
       );
 


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Changes the load in point of the plugin, such that it now generates the parsed elements from annotations after the service is fully loaded, allowing us to accurately fetch the key properties from associations directly from the source entity. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to https://github.com/gavdilabs/cap-mcp-plugin/issues/47

## What Changed

<!-- List the main changes made -->
- Switched the annotation parsing step from "loaded" to "serving" in the CDS life-cycle
- Removed duplicate association parsing from entity tools

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Create multi-key entity or simply an entity with a foreign key of not number
2. Run test tooling and ensure correct type is generated for the foreign key and/or the entity key


## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

