### PR TITLE
fix: permissions for GITHUB_TOKEN in actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout with SSH key
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds permission limitations to Github actions to minimize the access levels of the tokens.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [X] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## What Changed

<!-- List the main changes made -->
- Permissions added to release.yml workflow
- Permissions added to pr.yml workflow

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

