### PR TITLE
fix: Fixed CDS version for relaxed peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@sap/cds": "^9.4.3",
+        "@sap/cds": "^9",
         "express": "^4"
       }
     },
@@ -2434,9 +2434,9 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.4.3.tgz",
-      "integrity": "sha512-X0EuuGjM9I8DAl3j2E7gYpDae804/votP3y0lbEsk8RbyE6dWFX3k8Bx0q5UyE2Lmw2ID/44TA+iCTQBhFjfFg==",
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.4.4.tgz",
+      "integrity": "sha512-JJCHeEJF4xzFyZSf2ToocvVE9dyHfNLTRXOauOxlmpfyaLg97G7Qp+L4bD132eB0onBG9bQj3eH8DzBm0hVvIw==",
       "peer": true,
       "dependencies": {
         "@sap/cds-compiler": "^6.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "@sap/cds": "^9.4.3",
+    "@sap/cds": "^9",
     "express": "^4"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Fixes the CDS version at version 9 for more relaxed version comparison for peers, i.e. users.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to https://github.com/gavdilabs/cap-mcp-plugin/issues/71

## What Changed

<!-- List the main changes made -->
- Changed CDS version to relaxed v9 peer dependency check

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors


## Review Focus

<!-- Help reviewers know what to focus on -->
- [ ] Code quality and architecture
- [X] Test coverage and quality
- [X] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

