### PR TITLE
fix: Correct scoped WRITE restrictions based on CAP specs

### DIFF
--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -446,7 +446,7 @@ function translateOperationRestriction(
     case "CHANGE":
       return ["UPDATE"];
     case "WRITE":
-      return ["CREATE", "READ", "UPDATE", "DELETE"];
+      return ["CREATE", "UPDATE", "DELETE"];
     case "*":
       return ["CREATE", "READ", "UPDATE", "DELETE"];
     default:

--- a/test/unit/annotations/parser.spec.ts
+++ b/test/unit/annotations/parser.spec.ts
@@ -1537,7 +1537,7 @@ describe("Parser", () => {
         ]);
       });
 
-      test("Resource: WRITE operation maps to all CRUD (string grant)", () => {
+      test("Resource: WRITE operation maps to CRD (string grant)", () => {
         const model: csn.CSN = {
           definitions: {
             "TestService.RestrictedEntity": {
@@ -1567,7 +1567,7 @@ describe("Parser", () => {
         expect(annotation.restrictions).toEqual([
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });
@@ -1721,7 +1721,7 @@ describe("Parser", () => {
         expect(annotation.restrictions).toEqual([
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });
@@ -1844,7 +1844,7 @@ describe("Parser", () => {
           { role: "authenticated-user", operations: ["DELETE"] },
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });

--- a/test/unit/annotations/utils.spec.ts
+++ b/test/unit/annotations/utils.spec.ts
@@ -1032,7 +1032,7 @@ describe("Utils", () => {
         ]);
       });
 
-      test("should map WRITE to all CRUD operations (string grant)", () => {
+      test("should map WRITE to CUD operations (string grant)", () => {
         const restrictions: CdsRestriction[] = [
           {
             grant: "WRITE",
@@ -1044,12 +1044,12 @@ describe("Utils", () => {
         expect(result).toEqual([
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });
 
-      test("should map WRITE to all CRUD operations (array grant)", () => {
+      test("should map WRITE to CUD operations (array grant)", () => {
         const restrictions: CdsRestriction[] = [
           {
             grant: ["WRITE"],
@@ -1061,11 +1061,11 @@ describe("Utils", () => {
         expect(result).toEqual([
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
           {
             role: "superuser",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });
@@ -1082,7 +1082,7 @@ describe("Utils", () => {
         expect(result).toEqual([
           {
             role: "poweruser",
-            operations: ["READ", "CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["READ", "CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });
@@ -1164,7 +1164,7 @@ describe("Utils", () => {
           { role: "authenticated-user", operations: ["DELETE"] },
           {
             role: "admin",
-            operations: ["CREATE", "READ", "UPDATE", "DELETE"],
+            operations: ["CREATE", "UPDATE", "DELETE"],
           },
         ]);
       });


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Corrects the WRITE restriction to only grant CREATE, UPDATE, and DELETE. UPSERT is not included as we do not support that as part of MCP plugin yet.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #75 

## What Changed

<!-- List the main changes made -->
- Limited WRITE restriction to not include READ capabilities
- Corrected automated tests to reflect truth

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [X] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

