### PR TITLE
fix: Remove left-over console.log statements

### DIFF
--- a/src/annotations/parser.ts
+++ b/src/annotations/parser.ts
@@ -207,15 +207,11 @@ function constructResourceAnnotation(
       .map(([k, _]) => k),
   );
 
-  console.log("I AM TRYING TO PARSE", model.definitions);
-
   const omittedFields = new Set<string>(
     Object.entries(model.definitions?.[entityTarget].elements ?? {})
       .filter(([_, v]) => (v as any)[MCP_OMIT_PROP_KEY])
       .map(([k, _]) => k),
   );
-
-  console.log("OMITTED FIELDS", omittedFields);
 
   const { properties, resourceKeys, propertyHints } = parseResourceElements(
     definition,


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Removes 2 console.log statements left over from a previous test run of the plugin. 

The console.log statements were accidentally left in prior to the release of 1.3. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes https://github.com/gavdilabs/cap-mcp-plugin/issues/89

## What Changed

<!-- List the main changes made -->
- `console.log` statements removed from parser

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

