### PR TITLE
fix: ISO Date Validation in Zod

### DIFF
--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -24,13 +24,13 @@ export function determineMcpParameterType(
     case "UUID":
       return z.string();
     case "Date":
-      return z.date();
+      return z.coerce.date();
     case "Time":
-      return z.date();
+      return z.coerce.date();
     case "DateTime":
-      return z.date();
+      return z.coerce.date();
     case "Timestamp":
-      return z.number();
+      return z.coerce.date();
     case "Integer":
       return z.number();
     case "Int16":
@@ -58,13 +58,13 @@ export function determineMcpParameterType(
     case "StringArray":
       return z.array(z.string());
     case "DateArray":
-      return z.array(z.date());
+      return z.array(z.coerce.date());
     case "TimeArray":
-      return z.array(z.date());
+      return z.array(z.coerce.date());
     case "DateTimeArray":
-      return z.array(z.date());
+      return z.array(z.coerce.date());
     case "TimestampArray":
-      return z.array(z.number());
+      return z.array(z.coerce.date());
     case "UUIDArray":
       return z.array(z.string());
     case "IntegerArray":

--- a/test/demo/db/schema.cds
+++ b/test/demo/db/schema.cds
@@ -1,11 +1,14 @@
 namespace my.bookshop;
 
 entity Books {
-  key ID            : Integer @mcp.hint: 'Must be a unique number not already in the system';
+  key ID            : Integer   @mcp.hint: 'Must be a unique number not already in the system';
       title         : String;
-      stock         : Integer @mcp.hint: 'The amount of books currently on store shelves';
-      computedValue : Integer @Core.Computed;
-      secretMessage : String  @mcp.omit;
+      stock         : Integer   @mcp.hint: 'The amount of books currently on store shelves';
+      computedValue : Integer   @Core.Computed;
+      secretMessage : String    @mcp.omit;
+      publishDate   : Date      @mcp.hint: 'Publication date in ISO 8601 format (YYYY-MM-DD)';
+      lastUpdated   : DateTime  @mcp.hint: 'Last update timestamp in ISO 8601 format';
+      createdAt     : Timestamp @mcp.hint: 'Creation timestamp (ISO 8601 or epoch milliseconds)';
       author        : Association to Authors;
 }
 

--- a/test/demo/srv/cat-service.cds
+++ b/test/demo/srv/cat-service.cds
@@ -150,6 +150,17 @@ service CatalogService {
     tool       : true
   }
   function getNotReal(value : my.TValidQuantities:positiveOnly)                                                    returns String;
+
+  @mcp: {
+    name       : 'get-books-by-date',
+    description: 'Gets books published on or after the specified date',
+    tool       : true
+  }
+  function getBooksByDate(
+    publishDate : Date      @mcp.hint: 'Publication date in ISO 8601 format (YYYY-MM-DD)',
+    updatedAfter: DateTime  @mcp.hint: 'Filter by last updated timestamp (ISO 8601)',
+    createdAfter: Timestamp @mcp.hint: 'Filter by creation timestamp (ISO 8601 or epoch ms)'
+  ) returns array of String;
 }
 
 annotate CatalogService with @mcp.prompts: [{

--- a/test/demo/srv/cat-service.js
+++ b/test/demo/srv/cat-service.js
@@ -38,6 +38,16 @@ class CatalogService extends cds.ApplicationService {
       const result = await cds.run(query);
       return result?.stock;
     });
+
+    this.on("getBooksByDate", async (req) => {
+      // This handler validates that date parameters are received correctly
+      const { publishDate, updatedAfter, createdAfter } = req.data;
+      return [
+        `publishDate: ${publishDate}`,
+        `updatedAfter: ${updatedAfter}`,
+        `createdAfter: ${createdAfter}`,
+      ];
+    });
   }
 }
 

--- a/test/integration/fixtures/test-server.ts
+++ b/test/integration/fixtures/test-server.ts
@@ -128,6 +128,9 @@ export class TestMcpServer {
             author: { type: "cds.String" },
             price: { type: "cds.Decimal" },
             stock: { type: "cds.Integer" },
+            publishDate: { type: "cds.Date" },
+            lastUpdated: { type: "cds.DateTime" },
+            createdAt: { type: "cds.Timestamp" },
             authorRef: {
               type: "cds.Association",
               target: "TestService.Authors",
@@ -159,6 +162,18 @@ export class TestMcpServer {
           "@mcp.tool": true,
           params: {
             bookId: { type: "cds.Integer" },
+          },
+          returns: { type: "cds.String" },
+        },
+        "TestService.getBooksByDate": {
+          kind: "function",
+          "@mcp.name": "get-books-by-date",
+          "@mcp.description": "Get books by date parameters",
+          "@mcp.tool": true,
+          params: {
+            publishDate: { type: "cds.Date" },
+            updatedAfter: { type: "cds.DateTime" },
+            createdAfter: { type: "cds.Timestamp" },
           },
           returns: { type: "cds.String" },
         },

--- a/test/integration/http-api/mcp-iso-date-validation.spec.ts
+++ b/test/integration/http-api/mcp-iso-date-validation.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * Integration tests for ISO 8601 date/time validation in MCP tool calls
+ *
+ * These tests verify that ISO 8601 date strings (the standard format used by AI agents)
+ * are correctly accepted by MCP tool calls and entity wrapper operations.
+ *
+ * Related issue: https://github.com/gavdilabs/cap-mcp-plugin/issues/102
+ */
+
+import request from "supertest";
+import { TestMcpServer } from "../fixtures/test-server";
+
+describe("MCP HTTP API - ISO 8601 Date Validation", () => {
+  let testServer: TestMcpServer;
+  let app: any;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    testServer = new TestMcpServer();
+    await testServer.setup();
+    app = testServer.getApp();
+
+    // Initialize session
+    const initResponse = await request(app)
+      .post("/mcp")
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json, text/event-stream")
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {
+            resources: { subscribe: true },
+            tools: {},
+            prompts: {},
+          },
+          clientInfo: {
+            name: "test-client",
+            version: "1.0.0",
+          },
+        },
+      })
+      .expect(200);
+
+    sessionId = initResponse.headers["mcp-session-id"];
+  });
+
+  afterEach(async () => {
+    await testServer.stop();
+  });
+
+  describe("Tool calls with ISO 8601 date parameters", () => {
+    it("should accept ISO 8601 date string for Date parameter", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "get-books-by-date",
+            arguments: {
+              publishDate: "2026-01-06",
+              updatedAfter: "2026-01-06T16:04:43Z",
+              createdAfter: "2026-01-06T16:04:43.123Z",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      // Validation should pass - error should be about service execution, not validation
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+      // If there's an error, it should be a service error (validation passed), not a validation error
+      if (responseData.result.isError) {
+        const errorText = responseData.result.content?.[0]?.text || "";
+        // Should not contain Zod validation errors
+        expect(errorText).not.toMatch(/invalid.*date/i);
+        expect(errorText).not.toMatch(/expected.*date/i);
+        expect(errorText).not.toMatch(/invalid_type/i);
+      }
+    });
+
+    it("should accept ISO 8601 datetime with timezone offset", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: {
+            name: "get-books-by-date",
+            arguments: {
+              publishDate: "2026-01-06",
+              updatedAfter: "2026-01-06T16:04:43+08:00",
+              createdAfter: "2026-01-06T16:04:43-05:00",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+      if (responseData.result.isError) {
+        const errorText = responseData.result.content?.[0]?.text || "";
+        expect(errorText).not.toMatch(/invalid.*date/i);
+        expect(errorText).not.toMatch(/expected.*date/i);
+        expect(errorText).not.toMatch(/invalid_type/i);
+      }
+    });
+
+    it("should accept epoch milliseconds for Timestamp parameter", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 4,
+          method: "tools/call",
+          params: {
+            name: "get-books-by-date",
+            arguments: {
+              publishDate: "2026-01-06",
+              updatedAfter: "2026-01-06T16:04:43Z",
+              createdAfter: 1736159083000, // Epoch milliseconds
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+      if (responseData.result.isError) {
+        const errorText = responseData.result.content?.[0]?.text || "";
+        expect(errorText).not.toMatch(/invalid.*date/i);
+        expect(errorText).not.toMatch(/expected.*date/i);
+        expect(errorText).not.toMatch(/invalid_type/i);
+      }
+    });
+  });
+
+  describe("Entity wrapper create with date fields", () => {
+    it("should accept ISO 8601 dates in entity create operation", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_create",
+            arguments: {
+              ID: 999,
+              title: "Test Book",
+              stock: 10,
+              publishDate: "2026-01-06",
+              lastUpdated: "2026-01-06T16:04:43Z",
+              createdAt: "2026-01-06T16:04:43.123Z",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      // Should not have a validation error - dates should be accepted
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+      // The actual create may fail due to constraints, but validation should pass
+    });
+
+    it("should accept epoch milliseconds for Timestamp in entity create", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 6,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_create",
+            arguments: {
+              ID: 998,
+              title: "Test Book 2",
+              stock: 5,
+              publishDate: "2026-01-06",
+              lastUpdated: "2026-01-06T16:04:43Z",
+              createdAt: 1736159083000, // Epoch milliseconds
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+    });
+  });
+
+  describe("Entity wrapper update with date fields", () => {
+    it("should accept ISO 8601 dates in entity update operation", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: {
+            name: "TestService_Books_update",
+            arguments: {
+              ID: 1,
+              lastUpdated: "2026-01-07T10:00:00+08:00",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      // Should not have a validation error
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+    });
+  });
+
+  describe("Edge cases for date validation", () => {
+    it("should handle datetime with microsecond precision", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 8,
+          method: "tools/call",
+          params: {
+            name: "get-books-by-date",
+            arguments: {
+              publishDate: "2026-01-06",
+              updatedAfter: "2026-01-06T16:04:43.123456Z",
+              createdAfter: "2026-01-06T16:04:43.123456789Z",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      expect(responseData.error).toBeUndefined();
+      expect(responseData.result).toBeDefined();
+      // If error, should not be a validation error
+      if (responseData.result.isError) {
+        const errorText = responseData.result.content?.[0]?.text || "";
+        expect(errorText).not.toMatch(/invalid.*date/i);
+        expect(errorText).not.toMatch(/expected.*date/i);
+        expect(errorText).not.toMatch(/invalid_type/i);
+      }
+    });
+
+    it("should reject invalid date strings with validation error", async () => {
+      const response = await request(app)
+        .post("/mcp")
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json, text/event-stream")
+        .set("mcp-session-id", sessionId)
+        .send({
+          jsonrpc: "2.0",
+          id: 9,
+          method: "tools/call",
+          params: {
+            name: "get-books-by-date",
+            arguments: {
+              publishDate: "not-a-valid-date",
+              updatedAfter: "2026-01-06T16:04:43Z",
+              createdAfter: "2026-01-06T16:04:43.123Z",
+            },
+          },
+        })
+        .expect(200);
+
+      const responseData = response.body;
+
+      // Should have an error for invalid date
+      expect(
+        responseData.error ||
+          responseData.result?.isError ||
+          responseData.result?.content?.[0]?.text?.includes("error"),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/test/unit/mcp/iso-date-validation.spec.ts
+++ b/test/unit/mcp/iso-date-validation.spec.ts
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for ISO 8601 date/time validation in determineMcpParameterType
+ *
+ * These tests verify that the Zod schemas returned by determineMcpParameterType
+ * correctly accept ISO 8601 date strings (the standard format used by AI agents)
+ * in addition to other valid formats.
+ *
+ * Related issue: https://github.com/gavdilabs/cap-mcp-plugin/issues/102
+ */
+
+// Set up global.cds BEFORE importing the module
+(global as any).cds = {
+  model: { definitions: {} },
+  test: jest.fn().mockResolvedValue(undefined),
+  services: {},
+  connect: { to: jest.fn() },
+  User: {
+    privileged: { id: "privileged", name: "Privileged User" },
+    anonymous: { id: "anonymous", _is_anonymous: true },
+  },
+  context: { user: null },
+};
+
+// Import the actual function (not mocked) to test real Zod validation behavior
+import { determineMcpParameterType } from "../../../src/mcp/utils";
+
+describe("ISO 8601 Date Validation - determineMcpParameterType", () => {
+  describe("Date type", () => {
+    it("should accept ISO 8601 date string (YYYY-MM-DD)", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("2026-01-06");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO 8601 datetime string for Date type", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("2026-01-06T00:00:00Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid date strings", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("not-a-valid-date");
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject empty strings", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("");
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("DateTime type", () => {
+    it("should accept ISO 8601 datetime string with timezone offset", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("2026-01-06T16:04:43+08:00");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO 8601 datetime string with Z suffix (UTC)", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("2026-01-06T16:04:43Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO 8601 datetime string without timezone", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("2026-01-06T16:04:43");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO 8601 date-only string for DateTime", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("2026-01-06");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid datetime strings", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("invalid-datetime");
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Time type", () => {
+    // Note: z.coerce.date() requires a full date string, not just time.
+    // AI agents typically send full ISO datetime strings even for Time fields.
+
+    it("should accept full ISO datetime string for Time type", () => {
+      const schema = determineMcpParameterType("Time");
+      // AI agents send full datetime even for time fields
+      const result = schema.safeParse("2026-01-06T16:04:43Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO datetime with timezone for Time type", () => {
+      const schema = determineMcpParameterType("Time");
+      const result = schema.safeParse("2026-01-06T16:04:43+08:00");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid time strings", () => {
+      const schema = determineMcpParameterType("Time");
+      const result = schema.safeParse("not-a-time");
+
+      expect(result.success).toBe(false);
+    });
+
+    it("should reject time-only strings (require full datetime)", () => {
+      const schema = determineMcpParameterType("Time");
+      // Time-only strings don't parse with z.coerce.date()
+      // AI agents should send full ISO datetime strings
+      const result = schema.safeParse("16:04:43");
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Timestamp type", () => {
+    it("should accept ISO 8601 datetime string with milliseconds", () => {
+      const schema = determineMcpParameterType("Timestamp");
+      const result = schema.safeParse("2026-01-06T16:04:43.123Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept ISO 8601 datetime string without milliseconds", () => {
+      const schema = determineMcpParameterType("Timestamp");
+      const result = schema.safeParse("2026-01-06T16:04:43Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept epoch milliseconds as number", () => {
+      const schema = determineMcpParameterType("Timestamp");
+      const result = schema.safeParse(1736159083000);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject invalid timestamp strings", () => {
+      const schema = determineMcpParameterType("Timestamp");
+      const result = schema.safeParse("not-a-timestamp");
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Array types with dates", () => {
+    it("should accept array of ISO 8601 date strings for DateArray", () => {
+      const schema = determineMcpParameterType("DateArray");
+      const result = schema.safeParse(["2026-01-06", "2026-01-07"]);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept array of ISO 8601 datetime strings for DateTimeArray", () => {
+      const schema = determineMcpParameterType("DateTimeArray");
+      const result = schema.safeParse([
+        "2026-01-06T16:04:43Z",
+        "2026-01-07T10:00:00+08:00",
+      ]);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept array of ISO 8601 datetime strings for TimeArray", () => {
+      const schema = determineMcpParameterType("TimeArray");
+      // AI agents send full datetime strings even for time fields
+      const result = schema.safeParse([
+        "2026-01-06T16:04:43Z",
+        "2026-01-06T10:00:00Z",
+      ]);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept array of ISO 8601 timestamp strings for TimestampArray", () => {
+      const schema = determineMcpParameterType("TimestampArray");
+      const result = schema.safeParse([
+        "2026-01-06T16:04:43.123Z",
+        "2026-01-07T10:00:00.456Z",
+      ]);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should accept mixed array with epoch and ISO strings for TimestampArray", () => {
+      const schema = determineMcpParameterType("TimestampArray");
+      const result = schema.safeParse([
+        1736159083000,
+        "2026-01-07T10:00:00.456Z",
+      ]);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should reject array with invalid date strings", () => {
+      const schema = determineMcpParameterType("DateArray");
+      const result = schema.safeParse(["2026-01-06", "invalid-date"]);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should handle ISO 8601 with negative timezone offset", () => {
+      const schema = determineMcpParameterType("DateTime");
+      const result = schema.safeParse("2026-01-06T16:04:43-05:00");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle ISO 8601 with microsecond precision", () => {
+      const schema = determineMcpParameterType("Timestamp");
+      const result = schema.safeParse("2026-01-06T16:04:43.123456Z");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle minimum valid date", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("0001-01-01");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle leap year date", () => {
+      const schema = determineMcpParameterType("Date");
+      const result = schema.safeParse("2024-02-29");
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/test/unit/mcp/utils.spec.ts
+++ b/test/unit/mcp/utils.spec.ts
@@ -75,6 +75,9 @@ jest.mock("zod", () => ({
     ),
     any: jest.fn(() => "any-type"),
     object: jest.fn(() => "object-type"),
+    coerce: {
+      date: jest.fn(() => ({ ...mockZodType, _type: "coerce-date-type" })),
+    },
   },
 }));
 
@@ -96,21 +99,21 @@ describe("Server Utils", () => {
       expect(result).toMatchObject({ _type: "string-type" });
     });
 
-    test("should return date type for Date CDS types", () => {
+    test("should return coerced date type for Date CDS types", () => {
       const dateTypes = ["Date", "Time", "DateTime"];
 
       dateTypes.forEach((type) => {
         const result = determineMcpParameterType(type);
-        expect(result).toMatchObject({ _type: "date-type" });
+        expect(result).toMatchObject({ _type: "coerce-date-type" });
       });
 
-      expect(z.date).toHaveBeenCalledTimes(dateTypes.length);
+      expect(z.coerce.date).toHaveBeenCalledTimes(dateTypes.length);
     });
 
-    test("should return number type for Timestamp CDS type", () => {
+    test("should return coerced date type for Timestamp CDS type", () => {
       const result = determineMcpParameterType("Timestamp");
-      expect(z.number).toHaveBeenCalled();
-      expect(result).toMatchObject({ _type: "number-type" });
+      expect(z.coerce.date).toHaveBeenCalled();
+      expect(result).toMatchObject({ _type: "coerce-date-type" });
     });
 
     test("should return number type for Integer CDS types", () => {


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Converts the current Zod validation behavior to use the coerce type instead of just regular `z.date()`. This will allow zod to take in coerce the date string into a date object. For reference, see [this StackOverflow answer](https://stackoverflow.com/a/77157250)

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #103 
- Fixes #102 

## What Changed

<!-- List the main changes made -->
- Changed utils to use `z.coerce.date()` instead of `z.date()`
- Added additional automated tests

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [ ] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Create CAP service with date based properties and expose them to MCP
2. Ask agent to send ISO string to endpoint as part of input

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [] API changes (documented below)
- [X] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

