### PR TITLE
fix: Remove string coercion from update and create tools

### DIFF
--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -572,16 +572,12 @@ function registerCreateTool(
         // Regular association - use foreign key
         const fkName = `${propName}_ID`;
         if (args[fkName] !== undefined) {
-          const val = (args as any)[fkName];
-          data[fkName] =
-            typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+          data[fkName] = args[fkName];
         }
         continue;
       }
       if (args[propName] !== undefined) {
-        const val = (args as any)[propName];
-        data[propName] =
-          typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+        data[propName] = args[propName];
       }
     }
 
@@ -723,16 +719,12 @@ function registerUpdateTool(
         // Regular association - use foreign key
         const fkName = `${propName}_ID`;
         if (args[fkName] !== undefined) {
-          const val = (args as any)[fkName];
-          updates[fkName] =
-            typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+          updates[fkName] = args[fkName];
         }
         continue;
       }
       if (args[propName] !== undefined) {
-        const val = (args as any)[propName];
-        updates[propName] =
-          typeof val === "string" && /^\d+$/.test(val) ? Number(val) : val;
+        updates[propName] = args[propName];
       }
     }
     if (Object.keys(updates).length === 0) {


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Removes the string coercion logic on both create and update entity tools, moving the parsing and validation logic down into the CAP layer. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes #107 

## What Changed

<!-- List the main changes made -->
- String coercion removed from create tool
- String coercion removed from update tool

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
See associated issue (#107)

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [X] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [X] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->
Noted that the logic for the entity tools is currently inefficient and contains quite a lot of duplicated logic. This should be refactored when time is available. 

---

