### PR TITLE
feat: add @mcp.wrap.name for custom tool naming

### DIFF
--- a/docs/guide/entity-wrappers.md
+++ b/docs/guide/entity-wrappers.md
@@ -26,6 +26,26 @@ For an annotated entity like `CatalogService.Books`, the plugin can generate:
 
 **Naming Convention**: `Service_Entity_Mode` - intentionally descriptive for both humans and AI agents.
 
+### Custom Tool Naming
+
+Customize the tool name prefix using `@mcp.wrap.name`:
+
+```cds
+annotate CatalogService.Books with @mcp.wrap: {
+  tools: true,
+  name: 'BookCatalog',
+  modes: ['query', 'get']
+};
+```
+
+**Result**: Generates `BookCatalog_query` and `BookCatalog_get` instead of `CatalogService_Books_query` and `CatalogService_Books_get`.
+
+**Use cases**:
+- Shorter, more concise tool names
+- Abstract away internal entity names
+- Align tool names with business terminology
+
+
 ## Enabling Entity Wrappers
 
 ### Global Configuration

--- a/src/annotations/constants.ts
+++ b/src/annotations/constants.ts
@@ -23,6 +23,7 @@ export const MCP_ANNOTATION_MAPPING = new Map<string, string>([
   ["@mcp.wrap", "wrap"],
   ["@mcp.wrap.tools", "wrap.tools"],
   ["@mcp.wrap.modes", "wrap.modes"],
+  ["@mcp.wrap.name", "wrap.name"],
   ["@mcp.wrap.hint", "wrap.hint"],
   ["@mcp.wrap.hint.get", "wrap.hint.get"],
   ["@mcp.wrap.hint.query", "wrap.hint.query"],

--- a/src/annotations/types.ts
+++ b/src/annotations/types.ts
@@ -129,6 +129,8 @@ export type McpAnnotationWrap = {
   tools?: boolean;
   /** Tool modes to create; defaults are provided via configuration */
   modes?: EntityOperationMode[];
+  /** Custom name prefix for generated tools (e.g., 'BookCatalog' generates 'BookCatalog_query') */
+  name?: string;
   /** Additional description hint appended to tool descriptions */
   hint?: string | McpDetailedHint;
 };

--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -169,12 +169,18 @@ export function registerEntityWrappers(
  * Builds the visible tool name for a given operation mode.
  * We prefer a descriptive naming scheme that is easy for humans and LLMs:
  *   Service_Entity_mode
+ * If customName is provided via @mcp.wrap.name, uses customName_mode instead.
  */
 function nameFor(
   service: string,
   entity: string,
   suffix: EntityOperationMode,
+  customName?: string,
 ): string {
+  // Custom name takes priority - uses format: customName_suffix
+  if (customName) {
+    return `${customName}_${suffix}`;
+  }
   // Use explicit Service_Entity_suffix naming to match docs/tests
   const entityName = entity.split(".").pop()!; // keep original case
   const serviceName = service.split(".").pop()!; // keep original case
@@ -190,7 +196,12 @@ function registerQueryTool(
   server: McpServer,
   authEnabled: boolean,
 ): void {
-  const toolName = nameFor(resAnno.serviceName, resAnno.target, "query");
+  const toolName = nameFor(
+    resAnno.serviceName,
+    resAnno.target,
+    "query",
+    resAnno.wrap?.name,
+  );
 
   // Structured input schema for queries with guard for empty property lists
   const allKeys = Array.from(resAnno.properties.keys());
@@ -389,7 +400,12 @@ function registerGetTool(
   server: McpServer,
   authEnabled: boolean,
 ): void {
-  const toolName = nameFor(resAnno.serviceName, resAnno.target, "get");
+  const toolName = nameFor(
+    resAnno.serviceName,
+    resAnno.target,
+    "get",
+    resAnno.wrap?.name,
+  );
   const inputSchema: Record<string, z.ZodType> = {};
   for (const [k, cdsType] of resAnno.resourceKeys.entries()) {
     inputSchema[k] = (determineMcpParameterType(cdsType) as z.ZodType).describe(
@@ -493,7 +509,12 @@ function registerCreateTool(
   server: McpServer,
   authEnabled: boolean,
 ): void {
-  const toolName = nameFor(resAnno.serviceName, resAnno.target, "create");
+  const toolName = nameFor(
+    resAnno.serviceName,
+    resAnno.target,
+    "create",
+    resAnno.wrap?.name,
+  );
 
   const inputSchema: Record<string, z.ZodType> = {};
   for (const [propName, cdsType] of resAnno.properties.entries()) {
@@ -602,7 +623,12 @@ function registerUpdateTool(
   server: McpServer,
   authEnabled: boolean,
 ): void {
-  const toolName = nameFor(resAnno.serviceName, resAnno.target, "update");
+  const toolName = nameFor(
+    resAnno.serviceName,
+    resAnno.target,
+    "update",
+    resAnno.wrap?.name,
+  );
 
   const inputSchema: Record<string, z.ZodType> = {};
   // Keys required
@@ -735,7 +761,12 @@ function registerDeleteTool(
   server: McpServer,
   authEnabled: boolean,
 ): void {
-  const toolName = nameFor(resAnno.serviceName, resAnno.target, "delete");
+  const toolName = nameFor(
+    resAnno.serviceName,
+    resAnno.target,
+    "delete",
+    resAnno.wrap?.name,
+  );
 
   const inputSchema: Record<string, z.ZodType> = {};
   // Keys required for deletion


### PR DESCRIPTION
## Summary
This PR introduces the `@mcp.wrap.name` annotation, allowing developers to customize the naming of generated MCP tools. Instead of the default `Service_Entity_Operation` pattern, users can now specify a custom prefix (e.g., `MyCustomName_query`). Additionally, this PR removes an incorrect circular dependency in `package.json`.
## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [x] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes
## Related Issues
<!-- Link related issues, use "Fixes #123" to auto-close -->
- Relates to #109 
## What Changed
<!-- List the main changes made -->
- Added `@mcp.wrap.name` to annotation mappings in `constants.ts` and types in `types.ts`.
- Updated `nameFor()` function in `entity-tools.ts` to accept and prioritize an optional `customName`.
- Modified all tool registration functions (`query`, `get`, `create`, `update`, `delete`) to pass the value of `@mcp.wrap.name`.
- Added comprehensive unit tests in `entity-tools.spec.ts` to verify custom naming, default fallbacks, and multi-mode support.
- Updated `entity-wrappers.md` documentation with usage examples.
- Removed self-referencing `@gavdi/cap-mcp` dependency from `package.json`.
## Testing
<!-- Mark completed testing with "x" -->
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing completed
- [x] No new warnings/errors
**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Annotate a CDS entity with `@mcp.wrap: { name: 'BookCatalog', tools: true, modes: ['query'] }`.
2. Run the MCP server tests.
3. Verify that the generated tool is named `BookCatalog_query` instead of the default `Service_Entity_query`.
4. Verify that entities without the `name` property still use the default naming convention.
## Impact
<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [x] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [x] Documentation updated
## Review Focus
<!-- Help reviewers know what to focus on -->
- [x] Code quality and architecture
- [x] Test coverage and quality
- [ ] Performance and security
- [x] Documentation accuracy
- [ ] Breaking change handling
## Additional Context
<!-- Screenshots, links, or other relevant information -->
New documentation section added: "Custom Tool Naming".