### PR TITLE
fix(entity-tools): resolve key type coercion based on CDS metadata

### DIFF
--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -32,17 +32,17 @@ export function determineMcpParameterType(
     case "Timestamp":
       return z.coerce.date();
     case "Integer":
-      return z.number();
+      return z.number().int();
     case "Int16":
-      return z.number();
+      return z.number().int();
     case "Int32":
-      return z.number();
+      return z.number().int();
     case "Int64":
-      return z.number();
+      return z.union([z.string(), z.number().int()]).transform(String);
     case "UInt8":
-      return z.number();
+      return z.number().int().min(0);
     case "Decimal":
-      return z.number();
+      return z.union([z.string(), z.number()]).transform(String);
     case "Double":
       return z.number();
     case "Boolean":
@@ -68,17 +68,17 @@ export function determineMcpParameterType(
     case "UUIDArray":
       return z.array(z.string());
     case "IntegerArray":
-      return z.array(z.number());
+      return z.array(z.number().int());
     case "Int16Array":
-      return z.array(z.number());
+      return z.array(z.number().int());
     case "Int32Array":
-      return z.array(z.number());
+      return z.array(z.number().int());
     case "Int64Array":
-      return z.array(z.number());
+      return z.array(z.union([z.string(), z.number().int()]).transform(String));
     case "UInt8Array":
-      return z.array(z.number());
+      return z.array(z.number().int().min(0));
     case "DecimalArray":
-      return z.array(z.number());
+      return z.array(z.union([z.string(), z.number()]).transform(String));
     case "BooleanArray":
       return z.array(z.boolean());
     case "DoubleArray":

--- a/test/integration/http-api/mcp-complex-keys.spec.ts
+++ b/test/integration/http-api/mcp-complex-keys.spec.ts
@@ -66,7 +66,7 @@ describe("MCP HTTP API - Complex Keys Integration", () => {
 
       expect(getBooksSchema.properties).toHaveProperty("ID");
       expect(getBooksSchema.required).toContain("ID");
-      expect(getBooksSchema.properties.ID.type).toBe("number");
+      expect(getBooksSchema.properties.ID.type).toBe("integer");
 
       // Verify get tool for simple entity works
       const getBooksResponse = await request(app)


### PR DESCRIPTION
Key values containing only digits (e.g. "202402110001") were
unconditionally converted to Number, causing entity lookup failures
when the CDS key type is String.

Coercion now consults the CDS type from resourceKeys metadata and
only converts to Number for safe integer types (Integer, Int16,
Int32, UInt8). Int64 and Decimal values are normalized to strings
to prevent silent precision loss due to IEEE 754 limits. Double
remains a native JS number as it maps directly to IEEE 754 double.