### PR TITLE
Fixes #144

### DIFF
--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -414,50 +414,47 @@ function registerOAuthEndpoints(
     async (req: Request, res: Response): Promise<void> => {
       const baseUrl = buildPublicBaseUrl(req);
 
+      // XSUAA does not support DCR so we will respond with the pre-configured client_id
       // IAS does not support DCR so we will respond with the pre-configured client_id
-      if (kind === "ias") {
-        const enhancedResponse = {
-          client_id: credentials.clientid, // Add our CAP app's client ID
-          redirect_uris: req.body.redirect_uris || [
-            `${baseUrl}/oauth/callback`,
-          ],
-        };
-        LOGGER.debug(
-          "Provided static client_id during DCR registration process",
-        );
-        res.json(enhancedResponse);
-        return;
-      }
+      // if (kind === "ias") {
+      const enhancedResponse = {
+        client_id: credentials.clientid, // Add our CAP app's client ID
+        redirect_uris: req.body.redirect_uris || [`${baseUrl}/oauth/callback`],
+      };
+      LOGGER.debug("Provided static client_id during DCR registration process");
+      res.json(enhancedResponse);
+      return;
+      // }
 
       // Keep original implementation for XSUAA
-      try {
-        // Simple proxy for discovery - no CSRF needed
-        const response = await fetch(`${credentials.url}/oauth/register`, {
-          method: "GET",
-          headers: {
-            Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
-            Accept: "application/json",
-          },
-        });
+      // try {
+      //   // Simple proxy for discovery - no CSRF needed
+      //   const response = await fetch(`${credentials.url}/oauth/register`, {
+      //     method: "GET",
+      //     headers: {
+      //       Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
+      //       Accept: "application/json",
+      //     },
+      //   });
 
-        const xsuaaData = await response.json();
+      //   const xsuaaData = await response.json();
 
-        // Add missing required fields that MCP client expects
-        const enhancedResponse = {
-          ...xsuaaData, // Keep all XSUAA fields
-          client_id: credentials.clientid, // Add our CAP app's client ID
-          redirect_uris: [`${baseUrl}/oauth/callback`], // Add our callback URL for discovery
-        };
+      //   // Add missing required fields that MCP client expects
+      //   const enhancedResponse = {
+      //     ...xsuaaData, // Keep all XSUAA fields
+      //     client_id: credentials.clientid, // Add our CAP app's client ID
+      //     redirect_uris: [`${baseUrl}/oauth/callback`], // Add our callback URL for discovery
+      //   };
 
-        res.status(response.status).json(enhancedResponse);
-      } catch (error) {
-        LOGGER.error("OAuth registration discovery error:", error);
-        res.status(500).json({
-          error: "server_error",
-          error_description:
-            error instanceof Error ? error.message : "Unknown error",
-        });
-      }
+      //   res.status(response.status).json(enhancedResponse);
+      // } catch (error) {
+      //   LOGGER.error("OAuth registration discovery error:", error);
+      //   res.status(500).json({
+      //     error: "server_error",
+      //     error_description:
+      //       error instanceof Error ? error.message : "Unknown error",
+      //   });
+      // }
     },
   );
 
@@ -467,83 +464,80 @@ function registerOAuthEndpoints(
     async (req: Request, res: Response): Promise<void> => {
       const baseUrl = buildPublicBaseUrl(req);
 
+      // XSUAA does not support DCR so we will respond with the pre-configured client_id
       // IAS does not support DCR so we will respond with the pre-configured client_id
-      if (kind === "ias") {
-        const enhancedResponse = {
-          client_id: credentials.clientid, // Add our CAP app's client ID
-          redirect_uris: req.body.redirect_uris || [
-            `${baseUrl}/oauth/callback`,
-          ],
-        };
-        LOGGER.debug(
-          "Provided static client_id during DCR registration process",
-        );
-        res.json(enhancedResponse);
-        return;
-      }
+      // if (kind === "ias") {
+      const enhancedResponse = {
+        client_id: credentials.clientid, // Add our CAP app's client ID
+        redirect_uris: req.body.redirect_uris || [`${baseUrl}/oauth/callback`],
+      };
+      LOGGER.debug("Provided static client_id during DCR registration process");
+      res.json(enhancedResponse);
+      return;
+      // }
 
       // Keep original implementation for XSUAA
-      try {
-        // Step 1: Fetch CSRF token from XSUAA
-        const csrfResponse = await fetch(`${credentials.url}/oauth/register`, {
-          method: "GET",
-          headers: {
-            "X-CSRF-Token": "Fetch",
-            Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
-            Accept: "application/json",
-          },
-        });
+      // try {
+      // Step 1: Fetch CSRF token from XSUAA
+      // const csrfResponse = await fetch(`${credentials.url}/oauth/register`, {
+      //   method: "GET",
+      //   headers: {
+      //     "X-CSRF-Token": "Fetch",
+      //     Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
+      //     Accept: "application/json",
+      //   },
+      // });
 
-        if (!csrfResponse.ok) {
-          throw new Error(`CSRF fetch failed: ${csrfResponse.status}`);
-        }
+      // if (!csrfResponse.ok) {
+      //   throw new Error(`CSRF fetch failed: ${csrfResponse.status}`);
+      // }
 
-        // Step 2: Extract CSRF token and session cookie
-        const setCookieHeader = csrfResponse.headers.get("set-cookie") || "";
-        const csrfToken = extractCsrfFromCookie(setCookieHeader);
+      // Step 2: Extract CSRF token and session cookie
+      // const setCookieHeader = csrfResponse.headers.get("set-cookie") || "";
+      // const csrfToken = extractCsrfFromCookie(setCookieHeader);
 
-        if (!csrfToken) {
-          throw new Error("Could not extract CSRF token from XSUAA response");
-        }
+      // if (!csrfToken) {
+      //   throw new Error("Could not extract CSRF token from XSUAA response");
+      // }
 
-        // Step 3: Make actual registration POST with CSRF token
-        const registrationResponse = await fetch(
-          `${credentials.url}/oauth/register`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": csrfToken,
-              Cookie: setCookieHeader,
-              Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
-              Accept: "application/json",
-            },
-            body: JSON.stringify(req.body),
-          },
-        );
+      // Step 3: Make actual registration POST with CSRF token
+      // const registrationResponse = await fetch(
+      //   `${credentials.url}/oauth/register`,
+      //   {
+      //     method: "POST",
+      //     headers: {
+      //       "Content-Type": "application/json",
+      //       "X-CSRF-Token": csrfToken,
+      //       Cookie: setCookieHeader,
+      //       Authorization: `Basic ${Buffer.from(`${credentials.clientid}:${credentials.clientsecret}`).toString("base64")}`,
+      //       Accept: "application/json",
+      //     },
+      //     body: JSON.stringify(req.body),
+      //   },
+      // );
 
-        const xsuaaData = await registrationResponse.json();
+      // const xsuaaData = await registrationResponse.json();
 
-        // Add missing required fields that MCP client expects
-        const enhancedResponse = {
-          ...xsuaaData, // Keep all XSUAA fields
-          client_id: credentials.clientid, // Add our CAP app's client ID
-          redirect_uris: req.body.redirect_uris || [
-            `${baseUrl}/oauth/callback`,
-          ],
-        };
+      // Add missing required fields that MCP client expects
+      //   const enhancedResponse = {
+      //     ...xsuaaData, // Keep all XSUAA fields
+      //     client_id: credentials.clientid, // Add our CAP app's client ID
+      //     redirect_uris: req.body.redirect_uris || [
+      //       `${baseUrl}/oauth/callback`,
+      //     ],
+      //   };
 
-        LOGGER.debug("[AUTH] Register POST response", enhancedResponse);
+      //   LOGGER.debug("[AUTH] Register POST response", enhancedResponse);
 
-        res.status(registrationResponse.status).json(enhancedResponse);
-      } catch (error) {
-        LOGGER.error("OAuth registration error:", error);
-        res.status(500).json({
-          error: "server_error",
-          error_description:
-            error instanceof Error ? error.message : "Unknown error",
-        });
-      }
+      //   res.status(registrationResponse.status).json(enhancedResponse);
+      // } catch (error) {
+      //   LOGGER.error("OAuth registration error:", error);
+      //   res.status(500).json({
+      //     error: "server_error",
+      //     error_description:
+      //       error instanceof Error ? error.message : "Unknown error",
+      //   });
+      // }
     },
   );
 


### PR DESCRIPTION
## Summary

The XSUAA endpoint /oauth/register which is being used in the MCP authentication cycle is a non-official endpoint. Even though it responds to queries, its availability is not guaranteed. In the upcoming BTP updates (next few days) this endpoint will no longer respond and throw a 403.

The good news is that its usage is actually not required as the information the endpoint provides is not used in the MCP authentication cycle.

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [x] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [x] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes #144 

## What Changed

<!-- List the main changes made -->
- Treated the `/oauth/register` the same for XSUAA as for IAS (provide static client info)

## Testing

<!-- Mark completed testing with "x" -->
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [x] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
1. Remove auth bypass in `package.json` of demo app
2. `cds bind` to an XSUAA instance
3. Run demo app in hybrid mode and use Inspector for authentication cycle

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [x] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [ ] Code quality and architecture
- [ ] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context
BTP pre-prod: `https://<tenant>.authentication.sap.hana.ondemand.com/oauth/register` yields 403.
<!-- Screenshots, links, or other relevant information -->

---

