### PR TITLE
feat: make action/function parameters optional when notNull is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,40 @@ extend projection Books with actions {
 }
 ```
 
+#### Required vs Optional Parameters
+
+Parameters follow standard CDS nullability rules. A parameter declared `not null` is **required** in the MCP tool schema; a parameter without `not null` is **optional** and may be omitted by the AI agent.
+
+```cds
+@mcp: {
+  name       : 'search-items',
+  description: 'Search for items by keyword with optional filters',
+  tool       : true
+}
+function searchItems(
+  query    : String  not null,  // required — must be provided
+  category : String,            // optional — may be omitted
+  limit    : Integer,           // optional — may be omitted
+  format   : String             // optional — may be omitted
+) returns array of String;
+```
+
+The generated JSON Schema will list only `not null` parameters in the `required` array:
+
+```json
+{
+  "properties": {
+    "query":    { "type": "string" },
+    "category": { "type": "string" },
+    "limit":    { "type": "integer" },
+    "format":   { "type": "string" }
+  },
+  "required": ["query"]
+}
+```
+
+> **Note:** This behaviour applies to unbound functions and actions. Entity wrapper tools (`query`, `get`, `create`, `update`) derive nullability from the entity element definitions.
+
 #### Tool Elicitation
 
 Request user confirmation or input before tool execution using the `elicit` property:

--- a/src/annotations/utils.ts
+++ b/src/annotations/utils.ts
@@ -293,6 +293,7 @@ export function parseResourceElements(
 type OperationParameter = {
   type?: string | { ref: string[] };
   items?: { type: string | { ref: string[] } };
+  notNull?: boolean;
 };
 
 /**
@@ -344,7 +345,8 @@ export function parseOperationElements(
         continue;
       }
 
-      parseParam(k, v);
+      const optionalSuffix = v.notNull ? undefined : "Optional";
+      parseParam(k, v, optionalSuffix);
     }
   }
 

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -18,6 +18,11 @@ export function determineMcpParameterType(
   key?: string,
   target?: string,
 ): z.ZodType {
+  if (cdsType?.endsWith("Optional")) {
+    const baseType = cdsType.slice(0, -"Optional".length);
+    return determineMcpParameterType(baseType, key, target).optional();
+  }
+
   switch (cdsType) {
     case "String":
       return z.string();

--- a/test/unit/annotations/complex-keys.spec.ts
+++ b/test/unit/annotations/complex-keys.spec.ts
@@ -215,7 +215,7 @@ describe("Complex Keys Annotation Parser", () => {
                 "@mcp.description": "Process entity with complex keys",
                 "@mcp.tool": true,
                 params: {
-                  amount: { type: "cds.Decimal" },
+                  amount: { type: "cds.Decimal", notNull: true },
                 },
               },
             },
@@ -289,10 +289,10 @@ describe("Complex Keys Annotation Parser", () => {
             "@mcp.description": "Function working with complex key entities",
             "@mcp.tool": true,
             params: {
-              entityId: { type: "cds.UUID" },
-              randomKey: { type: "cds.Integer" },
-              otherRef: { type: "cds.UUID" }, // Reference to Other.ID
-              processMode: { type: "cds.String" },
+              entityId: { type: "cds.UUID", notNull: true },
+              randomKey: { type: "cds.Integer", notNull: true },
+              otherRef: { type: "cds.UUID", notNull: true }, // Reference to Other.ID
+              processMode: { type: "cds.String", notNull: true },
             },
           },
         },

--- a/test/unit/annotations/parser.spec.ts
+++ b/test/unit/annotations/parser.spec.ts
@@ -230,6 +230,7 @@ describe("Parser", () => {
                 params: {
                   input: {
                     type: { ref: ["myTypes.CustomDouble", "double1"] },
+                    notNull: true,
                   },
                 },
               },
@@ -266,8 +267,9 @@ describe("Parser", () => {
             params: {
               complexParam: {
                 type: { ref: ["myTypes.ComplexType", "stringField"] },
+                notNull: true,
               },
-              simpleParam: { type: "cds.Boolean" },
+              simpleParam: { type: "cds.Boolean", notNull: true },
             },
           },
         },
@@ -310,8 +312,9 @@ describe("Parser", () => {
             params: {
               nestedComplexParam: {
                 type: { ref: ["myTypes.ComplexType", "stringField"] },
+                notNull: true,
               },
-              simpleParam: { type: "cds.Boolean" },
+              simpleParam: { type: "cds.Boolean", notNull: true },
             },
           },
         },
@@ -357,15 +360,19 @@ describe("Parser", () => {
             params: {
               personName: {
                 type: { ref: ["myTypes.Person", "name"] },
+                notNull: true,
               },
               personAge: {
                 type: { ref: ["myTypes.Person", "age"] },
+                notNull: true,
               },
               addressZip: {
                 type: { ref: ["myTypes.Address", "zipCode"] },
+                notNull: true,
               },
               isPersonActive: {
                 type: { ref: ["myTypes.Person", "isActive"] },
+                notNull: true,
               },
             },
           },
@@ -1000,11 +1007,11 @@ describe("Parser", () => {
             "@mcp.description": "Action with mixed parameter types",
             "@mcp.tool": true,
             params: {
-              singleValue: { type: "cds.String" },
+              singleValue: { type: "cds.String", notNull: true },
               arrayValues: {
                 items: { type: "cds.String" },
               },
-              numericValue: { type: "cds.Integer" },
+              numericValue: { type: "cds.Integer", notNull: true },
               numericArray: {
                 items: { type: "cds.Integer" },
               },
@@ -1093,7 +1100,7 @@ describe("Parser", () => {
                   quantities: {
                     items: { type: "cds.Integer" },
                   },
-                  enabled: { type: "cds.Boolean" },
+                  enabled: { type: "cds.Boolean", notNull: true },
                 },
               },
             },

--- a/test/unit/annotations/utils.spec.ts
+++ b/test/unit/annotations/utils.spec.ts
@@ -594,8 +594,8 @@ describe("Utils", () => {
         definition: {
           kind: "function",
           params: {
-            param1: { type: "cds.String" },
-            param2: { type: "cds.Integer" },
+            param1: { type: "cds.String", notNull: true },
+            param2: { type: "cds.Integer", notNull: true },
           },
         } as any,
         name: "test",
@@ -656,11 +656,11 @@ describe("Utils", () => {
         definition: {
           kind: "action",
           params: {
-            singleString: { type: "cds.String" },
+            singleString: { type: "cds.String", notNull: true },
             stringArray: {
               items: { type: "cds.String" },
             },
-            singleInteger: { type: "cds.Integer" },
+            singleInteger: { type: "cds.Integer", notNull: true },
             integerArray: {
               items: { type: "cds.Integer" },
             },
@@ -783,6 +783,47 @@ describe("Utils", () => {
 
       expect(result.parameters).toBeUndefined();
       expect(result.operationKind).toBe("action");
+    });
+
+    test("should mark parameters without notNull as Optional-suffixed", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "function",
+          params: {
+            required: { type: "cds.String", notNull: true },
+            optional: { type: "cds.String" },
+            alsoOptional: { type: "cds.Integer" },
+          },
+        } as any,
+        name: "test-optional",
+        description: "test optional parameters",
+      };
+
+      const mockModel: csn.CSN = { definitions: {} };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters).toBeDefined();
+      expect(result.parameters!.get("required")).toBe("String");
+      expect(result.parameters!.get("optional")).toBe("StringOptional");
+      expect(result.parameters!.get("alsoOptional")).toBe("IntegerOptional");
+    });
+
+    test("should mark notNull: false parameters as Optional-suffixed", () => {
+      const annotations: McpAnnotationStructure = {
+        definition: {
+          kind: "action",
+          params: {
+            explicit: { type: "cds.Boolean", notNull: false },
+          },
+        } as any,
+        name: "test-explicit-optional",
+        description: "test explicit notNull false",
+      };
+
+      const mockModel: csn.CSN = { definitions: {} };
+      const result = parseOperationElements(annotations, mockModel);
+
+      expect(result.parameters!.get("explicit")).toBe("BooleanOptional");
     });
   });
 

--- a/test/unit/mcp/utils.spec.ts
+++ b/test/unit/mcp/utils.spec.ts
@@ -246,6 +246,24 @@ describe("Server Utils", () => {
       expect(resultUpper).toMatchObject({ _type: "string-type" });
     });
 
+    test("should return optional wrapper for Optional-suffixed types", () => {
+      const result = determineMcpParameterType("StringOptional");
+      expect(mockOptional).toHaveBeenCalled();
+      expect(result).toBe("optional-type");
+    });
+
+    test("should return optional wrapper for BooleanOptional", () => {
+      const result = determineMcpParameterType("BooleanOptional");
+      expect(mockOptional).toHaveBeenCalled();
+      expect(result).toBe("optional-type");
+    });
+
+    test("should return optional wrapper for IntegerOptional", () => {
+      const result = determineMcpParameterType("IntegerOptional");
+      expect(mockOptional).toHaveBeenCalled();
+      expect(result).toBe("optional-type");
+    });
+
     describe("Composition type handling", () => {
       // Store original cds reference
       const originalCds = (global as any).cds;


### PR DESCRIPTION
## Summary
Parameters in CDS actions and functions without `not null` are now correctly marked optional in the generated Zod schema. Previously every parameter was treated as required regardless of its CDS nullability.

How it works:
- `parseOperationElements` appends an "Optional" suffix to the CDS type string for any parameter whose `notNull` flag is absent or false.
- `determineMcpParameterType` detects the "Optional" suffix, resolves the base type, then calls `.optional()` on the resulting Zod schema. The `required` array in the JSON Schema output therefore only contains parameters declared `not null` in CDS.

Existing tests updated to add `notNull: true` to fixtures that represent required parameters, making the intent of each test explicit. New tests added for `parseOperationElements` (optional suffix logic) and `determineMcpParameterType` (StringOptional, BooleanOptional, IntegerOptional).

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [x] 🚀 **Feature** - New functionality or enhancement
- [ ] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Testing

<!-- Mark completed testing with "x" -->
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] No new warnings/errors

## Impact

<!-- Mark any areas of impact -->
- [ ] Breaking changes (migration guide in description)
- [ ] API changes (documented below)
- [ ] Performance impact (benchmarks provided)
- [ ] Security implications (review requested)
- [ ] Documentation updated

## Review Focus

<!-- Help reviewers know what to focus on -->
- [x] Code quality and architecture
- [ ] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
---

