### PR TITLE
feat(mcp): emit tool annotations from CDS operation kind

### DIFF
--- a/src/mcp/entity-tools.ts
+++ b/src/mcp/entity-tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { McpResourceAnnotation } from "../annotations/structures";
 import { getAccessRights, WrapAccess } from "../auth/utils";
 import { LOGGER } from "../logger";
@@ -481,7 +482,16 @@ function registerQueryTool(
 
   server.registerTool(
     toolName,
-    { title: toolName, description: desc, inputSchema },
+    {
+      title: toolName,
+      description: desc,
+      inputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      } as ToolAnnotations,
+    },
     queryHandler as any,
   );
 }
@@ -588,7 +598,16 @@ function registerGetTool(
 
   server.registerTool(
     toolName,
-    { title: toolName, description: desc, inputSchema },
+    {
+      title: toolName,
+      description: desc,
+      inputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      } as ToolAnnotations,
+    },
     getHandler as any,
   );
 }
@@ -720,7 +739,16 @@ function registerCreateTool(
 
   server.registerTool(
     toolName,
-    { title: toolName, description: desc, inputSchema },
+    {
+      title: toolName,
+      description: desc,
+      inputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      } as ToolAnnotations,
+    },
     createHandler as any,
   );
 }
@@ -873,7 +901,16 @@ function registerUpdateTool(
 
   server.registerTool(
     toolName,
-    { title: toolName, description: desc, inputSchema },
+    {
+      title: toolName,
+      description: desc,
+      inputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      } as ToolAnnotations,
+    },
     updateHandler as any,
   );
 }
@@ -969,7 +1006,16 @@ function registerDeleteTool(
 
   server.registerTool(
     toolName,
-    { title: toolName, description: desc, inputSchema },
+    {
+      title: toolName,
+      description: desc,
+      inputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      } as ToolAnnotations,
+    },
     deleteHandler as any,
   );
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { McpToolAnnotation } from "../annotations/structures";
 import { determineMcpParameterType, asMcpResult } from "./utils";
 import { LOGGER } from "../logger";
@@ -40,6 +41,27 @@ export function assignToolToServer(
 }
 
 /**
+ * Derives MCP tool behaviour hints from a CDS operation kind.
+ *
+ * CDS `function`s are non-side-effecting reads, while `action`s are
+ * side-effecting writes. These map onto the MCP `ToolAnnotations` hints so
+ * clients can advertise read-only/destructive intent in `tools/list`.
+ *
+ * Any non-`function` kind (including an undefined kind) is treated as an
+ * action to stay on the safe, write-capable side.
+ * @param model - The tool annotation carrying the parsed operation kind
+ * @returns Tool annotation hints describing the operation's behaviour
+ */
+function buildOperationAnnotations(model: McpToolAnnotation): ToolAnnotations {
+  const readOnly = model.operationKind === "function";
+  return {
+    readOnlyHint: readOnly,
+    destructiveHint: !readOnly,
+    idempotentHint: readOnly,
+  };
+}
+
+/**
  * Registers a bound operation that operates on a specific entity instance
  * Requires entity key parameters in addition to operation parameters
  * @param params - Zod schema definitions for operation parameters
@@ -75,6 +97,7 @@ function assignBoundOperation(
       title: model.name,
       description: model.description,
       inputSchema: inputSchema,
+      annotations: buildOperationAnnotations(model),
     },
     async (args) => {
       // Resolve from current CAP context; prefer global to align with Jest mocks
@@ -150,6 +173,7 @@ function assignUnboundOperation(
       title: model.name,
       description: model.description,
       inputSchema: inputSchema,
+      annotations: buildOperationAnnotations(model),
     },
     async (args) => {
       // Resolve from current CAP context; prefer global to align with Jest mocks

--- a/test/unit/mcp/entity-tools.spec.ts
+++ b/test/unit/mcp/entity-tools.spec.ts
@@ -111,6 +111,71 @@ describe("entity-tools - registration", () => {
     const accesses: WrapAccess = { canDelete: true };
     registerEntityWrappers(res, server, false, ["delete"], accesses);
   });
+
+  it("emits behaviour annotations per entity wrapper mode", () => {
+    const server = new McpServer({ name: "t", version: "1" });
+    const annotations: Record<string, any> = {};
+    // @ts-ignore override registerTool to capture annotations
+    server.registerTool = (name: string, config: any) => {
+      annotations[name] = config.annotations;
+      return undefined as any;
+    };
+
+    const res = new McpResourceAnnotation(
+      "books",
+      "Books",
+      "Books",
+      "CatalogService",
+      new Set(["filter", "orderby", "select", "top", "skip"]),
+      new Map([
+        ["ID", "Integer"],
+        ["title", "String"],
+      ]),
+      new Map([["ID", "Integer"]]),
+      new Map(),
+      { tools: true, modes: ["query", "get", "create", "update", "delete"] },
+    );
+
+    const accesses: WrapAccess = {
+      canRead: true,
+      canCreate: true,
+      canUpdate: true,
+      canDelete: true,
+    };
+    registerEntityWrappers(
+      res,
+      server,
+      false,
+      ["query", "get", "create", "update", "delete"],
+      accesses,
+    );
+
+    expect(annotations["CatalogService_Books_query"]).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+    expect(annotations["CatalogService_Books_get"]).toEqual({
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+    expect(annotations["CatalogService_Books_create"]).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    });
+    expect(annotations["CatalogService_Books_update"]).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+    expect(annotations["CatalogService_Books_delete"]).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+    });
+  });
 });
 
 describe("entity-tools - custom tool naming via @mcp.wrap.name", () => {

--- a/test/unit/mcp/tools.spec.ts
+++ b/test/unit/mcp/tools.spec.ts
@@ -100,6 +100,11 @@ describe("tools.ts", () => {
             param1: expect.any(z.ZodString),
             param2: expect.any(z.ZodNumber),
           }),
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
         });
         expect(registerCall.args[2]).toEqual(expect.any(Function));
 
@@ -226,6 +231,11 @@ describe("tools.ts", () => {
           title: "TestTool",
           description: "Test tool description",
           inputSchema: {},
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
         });
         expect(registerCall.args[2]).toEqual(expect.any(Function));
       });
@@ -261,6 +271,11 @@ describe("tools.ts", () => {
           title: "TestTool",
           description: "Test tool description",
           inputSchema: {},
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
         });
         expect(registerCall.args[2]).toEqual(expect.any(Function));
       });
@@ -353,6 +368,11 @@ describe("tools.ts", () => {
             id: expect.any(z.ZodNumber),
             param1: expect.any(z.ZodString),
           }),
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+          },
         });
         expect(registerCall.args[2]).toEqual(expect.any(Function));
 
@@ -1199,6 +1219,90 @@ describe("tools.ts", () => {
             boolParam: true,
           },
           params: [{ id: "guid-123-456" }],
+        });
+      });
+    });
+
+    describe("Operation Annotations", () => {
+      it("emits read-only hints for CDS functions", () => {
+        const model = new McpToolAnnotation(
+          "ReadTool",
+          "A read-only function",
+          "readFunction",
+          "TestService",
+          new Map(),
+          undefined,
+          "function",
+        );
+
+        (cds as any).services["TestService"] = {
+          send: jest.fn(),
+          tx: jest.fn().mockReturnValue({ send: jest.fn() }),
+        };
+
+        assignToolToServer(model, mockServer as any, false);
+
+        const registerCall = (
+          mockServer.registerTool as sinon.SinonStub
+        ).getCall(0);
+        expect(registerCall.args[1].annotations).toEqual({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+        });
+      });
+
+      it("emits write hints for CDS actions", () => {
+        const model = new McpToolAnnotation(
+          "WriteTool",
+          "A side-effecting action",
+          "writeAction",
+          "TestService",
+          new Map(),
+          undefined,
+          "action",
+        );
+
+        (cds as any).services["TestService"] = {
+          send: jest.fn(),
+          tx: jest.fn().mockReturnValue({ send: jest.fn() }),
+        };
+
+        assignToolToServer(model, mockServer as any, false);
+
+        const registerCall = (
+          mockServer.registerTool as sinon.SinonStub
+        ).getCall(0);
+        expect(registerCall.args[1].annotations).toEqual({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
+        });
+      });
+
+      it("treats an unknown operation kind as a write for safety", () => {
+        const model = new McpToolAnnotation(
+          "UnknownTool",
+          "An operation without a declared kind",
+          "unknownOp",
+          "TestService",
+          new Map(),
+        );
+
+        (cds as any).services["TestService"] = {
+          send: jest.fn(),
+          tx: jest.fn().mockReturnValue({ send: jest.fn() }),
+        };
+
+        assignToolToServer(model, mockServer as any, false);
+
+        const registerCall = (
+          mockServer.registerTool as sinon.SinonStub
+        ).getCall(0);
+        expect(registerCall.args[1].annotations).toEqual({
+          readOnlyHint: false,
+          destructiveHint: true,
+          idempotentHint: false,
         });
       });
     });


### PR DESCRIPTION
## Summary

CDS `function`s are non-side-effecting reads; CDS `action`s are side-effecting writes. The MCP spec lets servers advertise this to clients via tool `annotations` (`readOnlyHint` / `destructiveHint` / `idempotentHint`).

The plugin **already parses** each operation's kind (it stores `operationKind` on `McpToolAnnotation`) but **dropped it**: `server.registerTool(...)` was called **without** an `annotations` field, so `tools/list` emitted **zero** annotations. The `@modelcontextprotocol/sdk` `registerTool` fully supports an `annotations` arg (`config.annotations?: ToolAnnotations`) and forwards it into `tools/list`. Verified that v1.6.0 still emits 0 annotations.

This PR wires the existing `operationKind` (and the known entity-wrapper modes) into the `annotations` the SDK already supports — purely **additive and backward-compatible**.

## Type of Change

- [x] 🚀 **Feature** - New functionality or enhancement

## What Changed

- `src/mcp/tools.ts`: added `buildOperationAnnotations(model)` deriving `{ readOnlyHint, destructiveHint, idempotentHint }` from `operationKind` (`function` => read-only/idempotent; `action` or unknown => destructive write). Passed as `annotations` on **both** the bound and unbound `registerTool` calls.
- `src/mcp/entity-tools.ts`: added static `annotations` to each of the 5 entity-wrapper `registerTool` calls.
- Added unit tests asserting the emitted `annotations` per operation kind and per entity wrapper mode.

### Per-kind mapping (operation tools)

| operationKind | readOnlyHint | destructiveHint | idempotentHint |
|---|---|---|---|
| `function` (read) | true | false | true |
| `action` / undefined (write) | false | true | false |

### Per-mode mapping (entity wrapper tools)

| mode | readOnlyHint | destructiveHint | idempotentHint |
|---|---|---|---|
| query | true | false | true |
| get | true | false | true |
| create | false | false | false |
| update | false | false | true |
| delete | false | true | true |

## Before / After (`tools/list`)

**Before:** every tool is returned with no `annotations` object — clients cannot tell reads from writes.

**After:** each tool carries hints, e.g. a `function`-backed tool returns `annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true }`, an `action`-backed tool returns `{ readOnlyHint: false, destructiveHint: true, idempotentHint: false }`, and entity wrappers return the per-mode hints above. Per the MCP spec these are advisory hints only.

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [x] No new warnings/errors

```
npm run build   # tsc clean
npm run lint    # eslint clean
npx prettier --check src/**/*.ts test/**/*.ts   # clean
npm test        # 48 suites, 898 tests passing
```

New tests:
- `test/unit/mcp/tools.spec.ts` — asserts read-only hints for `function`, write hints for `action`, and write hints for an undefined kind (safe default). Existing strict `toEqual` assertions on the `registerTool` config were updated to include the new `annotations` field.
- `test/unit/mcp/entity-tools.spec.ts` — asserts the emitted `annotations` for each of query/get/create/update/delete.

## Impact

- [x] No breaking changes — additive only; clients that ignore `annotations` are unaffected.
- [x] API changes (documented above)

## Additional Context

- All MCP annotations are **hints** per the spec (`ToolAnnotationsSchema`); clients should not make trust decisions based solely on them.
- I'm an **external contributor**. Per `CONTRIBUTING.md` I agree these contributions are licensed under **Apache-2.0**. If a CLA bot requires explicit acceptance, I'll complete it on request.
