### PR TITLE
fix: add body-parser configuration in bootstrap

### DIFF
--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -68,6 +68,15 @@ export default class McpPlugin {
       }),
     );
 
+    // Apply body limit
+    const limit =
+      cds.env.mcp?.body_parser?.limit ??
+      cds.env.server?.body_parser?.limit ??
+      "100kb"; // preserve current default if no config
+
+    this.expressApp.use("/mcp", express.json({ limit }));
+
+    // Handle auth configuration
     if (this.config.auth === "inherit") {
       registerAuthMiddleware(this.expressApp);
     }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Adds body-parser configuration to the bootstrap, such that it can be configured either through `cds.mcp` or `cds.server` and their associated environment configurations. 

This seems to be a leftover issue from when middleware was disconnected from standard CDS middleware. 

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## Related Issues

<!-- Link related issues, use "Fixes #123" to auto-close -->
- Fixes #150 

## What Changed

<!-- List the main changes made -->
-  `onBoostrap` now contains a loader for body-parser limits through configuration
- Defaults to 100kb

## Testing

<!-- Mark completed testing with "x" -->
- [X] Unit tests pass
- [X] Integration tests pass
- [X] Manual testing completed
- [X] No new warnings/errors

**Test Steps:**
<!-- For features/fixes, provide testing instructions -->
See associated issue for replication

## Review Focus

<!-- Help reviewers know what to focus on -->
- [X] Code quality and architecture
- [ ] Test coverage and quality
- [ ] Performance and security
- [ ] Documentation accuracy
- [ ] Breaking change handling

## Additional Context

<!-- Screenshots, links, or other relevant information -->

---

