### PR TITLE
fix: upgrade release-it to keep it from breaking during ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@cap-js/cds-types": "^0.18.0",
-        "@release-it/conventional-changelog": "^10.0.1",
+        "@release-it/conventional-changelog": "^11.0.1",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
@@ -35,7 +35,7 @@
         "lint-staged": "^16.1.2",
         "markdown-link-check": "^3.14.1",
         "prettier": "^3.5.3",
-        "release-it": "^19.0.4",
+        "release-it": "^20.2.1",
         "sinon": "^21.0.0",
         "supertest": "^7.0.0",
         "ts-jest": "^29.4.0",
@@ -544,12 +544,14 @@
       }
     },
     "node_modules/@conventional-changelog/git-client": {
-      "version": "2.5.1",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.1.0",
+        "@simple-libs/stream-utils": "^1.2.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -557,7 +559,7 @@
       },
       "peerDependencies": {
         "conventional-commits-filter": "^5.0.0",
-        "conventional-commits-parser": "^6.1.0"
+        "conventional-commits-parser": "^6.4.0"
       },
       "peerDependenciesMeta": {
         "conventional-commits-filter": {
@@ -845,30 +847,29 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -880,17 +881,17 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -902,23 +903,22 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -927,23 +927,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@inquirer/core/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@inquirer/core/node_modules/signal-exit": {
@@ -959,49 +942,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@inquirer/core/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1013,18 +966,17 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1036,17 +988,17 @@
       }
     },
     "node_modules/@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "iconv-lite": "^0.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1058,27 +1010,27 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1090,17 +1042,17 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1112,18 +1064,18 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1135,25 +1087,25 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+      "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.1.4",
+        "@inquirer/confirm": "^6.0.12",
+        "@inquirer/editor": "^5.1.1",
+        "@inquirer/expand": "^5.0.13",
+        "@inquirer/input": "^5.0.12",
+        "@inquirer/number": "^4.0.12",
+        "@inquirer/password": "^5.0.12",
+        "@inquirer/rawlist": "^5.2.8",
+        "@inquirer/search": "^4.1.8",
+        "@inquirer/select": "^5.1.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1165,18 +1117,17 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1188,19 +1139,18 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1212,20 +1162,19 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1237,13 +1186,13 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1766,14 +1715,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodeutils/defaults-deep": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lodash": "^4.15.0"
-      }
-    },
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -2007,28 +1948,31 @@
       }
     },
     "node_modules/@release-it/conventional-changelog": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-10.0.5.tgz",
-      "integrity": "sha512-Dxul3YlUsDLbIg+aR6T0QR/VyKwuJNR3GZM8mKVEwFO8GpH2H5vgnN7kacEvq/Qk5puDadOVbhbUq/KBjraemQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.1.tgz",
+      "integrity": "sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@conventional-changelog/git-client": "^2.5.1",
+        "@conventional-changelog/git-client": "^2.7.0",
         "concat-stream": "^2.0.0",
-        "conventional-changelog": "^7.1.1",
-        "conventional-changelog-angular": "^8.1.0",
-        "conventional-changelog-conventionalcommits": "^9.1.0",
+        "conventional-changelog": "^7.2.0",
+        "conventional-changelog-angular": "^8.3.1",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "conventional-recommended-bump": "^11.2.0",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "engines": {
-        "node": "^20.12.0 || >=22.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "release-it": "^18.0.0 || ^19.0.0"
+        "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0"
       }
     },
     "node_modules/@release-it/conventional-changelog/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2148,13 +2092,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@simple-libs/stream-utils": {
-      "version": "1.1.0",
+    "node_modules/@simple-libs/hosted-git-info": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+      "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.0.0"
-      },
       "engines": {
         "node": ">=18"
       },
@@ -2162,18 +2105,18 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@simple-libs/stream-utils/node_modules/@types/node": {
-      "version": "22.19.1",
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
       }
-    },
-    "node_modules/@simple-libs/stream-utils/node_modules/undici-types": {
-      "version": "6.21.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2608,6 +2551,8 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2928,6 +2873,8 @@
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
     },
@@ -3376,6 +3323,8 @@
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3560,9 +3509,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3853,6 +3802,8 @@
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4039,15 +3990,18 @@
       }
     },
     "node_modules/conventional-changelog": {
-      "version": "7.1.1",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.1.tgz",
+      "integrity": "sha512-smcpqCeNRCAoL586/Iql8GfVsduP1JDrr7SAzKHWM5C5voDzKhc3QtqwVWeKMhvVw4iYfAr+znz1TF4kPXVm3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@conventional-changelog/git-client": "^2.5.1",
+        "@conventional-changelog/git-client": "^2.7.0",
+        "@simple-libs/hosted-git-info": "^1.0.2",
         "@types/normalize-package-data": "^2.4.4",
         "conventional-changelog-preset-loader": "^5.0.0",
-        "conventional-changelog-writer": "^8.2.0",
-        "conventional-commits-parser": "^6.2.0",
+        "conventional-changelog-writer": "^8.4.0",
+        "conventional-commits-parser": "^6.4.0",
         "fd-package-json": "^2.0.0",
         "meow": "^13.0.0",
         "normalize-package-data": "^7.0.0"
@@ -4060,7 +4014,9 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.1.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4071,7 +4027,9 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.1.0",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4090,10 +4048,13 @@
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "8.2.0",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
         "meow": "^13.0.0",
@@ -4107,7 +4068,9 @@
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4126,10 +4089,13 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.2.1",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "meow": "^13.0.0"
       },
       "bin": {
@@ -4371,7 +4337,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.2.1",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4386,7 +4354,9 @@
       }
     },
     "node_modules/default-browser-id": {
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4403,6 +4373,8 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4413,9 +4385,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5312,9 +5284,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
-      "integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+      "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5641,6 +5613,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5656,6 +5645,16 @@
         }
       ]
     },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "dev": true,
@@ -5666,6 +5665,8 @@
     },
     "node_modules/fd-package-json": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6208,7 +6209,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6314,6 +6317,8 @@
     },
     "node_modules/hosted-git-info": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6325,6 +6330,8 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -6588,33 +6595,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/inquirer": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
-      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/prompts": "^7.10.1",
-        "@inquirer/type": "^3.0.10",
-        "mute-stream": "^2.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "dev": true,
@@ -6698,6 +6678,8 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6752,8 +6734,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6885,7 +6882,9 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7864,13 +7863,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "dev": true,
@@ -8001,7 +7993,9 @@
       }
     },
     "node_modules/macos-release": {
-      "version": "3.4.0",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+      "integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8274,13 +8268,13 @@
       "license": "MIT"
     },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nano-spawn": {
@@ -8343,6 +8337,8 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -8465,6 +8461,8 @@
     },
     "node_modules/normalize-package-data": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8477,7 +8475,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8606,17 +8606,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8652,9 +8656,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8664,28 +8668,14 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
       },
       "engines": {
         "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ora/node_modules/chalk": {
@@ -8701,32 +8691,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/os-name": {
-      "version": "6.1.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+      "integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "macos-release": "^3.3.0",
-        "windows-release": "^6.1.0"
+        "macos-release": "^3.4.0",
+        "windows-release": "^7.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9142,6 +9118,19 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -9377,6 +9366,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quickjs-wasi": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+      "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
@@ -9510,9 +9506,9 @@
       }
     },
     "node_modules/release-it": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
-      "integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+      "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
       "dev": true,
       "funding": [
         {
@@ -9526,41 +9522,51 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodeutils/defaults-deep": "1.1.0",
+        "@inquirer/prompts": "8.4.2",
         "@octokit/rest": "22.0.1",
         "@phun-ky/typeof": "2.0.3",
         "async-retry": "1.3.3",
         "c12": "3.3.3",
-        "ci-info": "^4.3.1",
-        "eta": "4.5.0",
+        "ci-info": "^4.4.0",
+        "defu": "^6.1.7",
+        "eta": "4.5.1",
         "git-url-parse": "16.1.0",
-        "inquirer": "12.11.1",
         "issue-parser": "7.0.1",
         "lodash.merge": "4.6.2",
         "mime-types": "3.0.2",
         "new-github-release-url": "2.0.0",
-        "open": "10.2.0",
-        "ora": "9.0.0",
-        "os-name": "6.1.0",
-        "proxy-agent": "6.5.0",
-        "semver": "7.7.3",
+        "open": "11.0.0",
+        "ora": "9.3.0",
+        "os-name": "7.0.0",
+        "proxy-agent": "7.0.0",
+        "semver": "7.7.4",
         "tinyglobby": "0.2.15",
-        "undici": "6.23.0",
+        "undici": "7.28.0",
         "url-join": "5.0.0",
         "wildcard-match": "5.1.4",
-        "yargs-parser": "21.1.1"
+        "yargs-parser": "22.0.0"
       },
       "bin": {
         "release-it": "bin/release-it.js"
       },
       "engines": {
-        "node": "^20.12.0 || >=22.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/release-it/node_modules/agent-base": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/release-it/node_modules/ci-info": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -9571,6 +9577,105 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/release-it/node_modules/data-uri-to-buffer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+      "integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/release-it/node_modules/degenerator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+      "integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^0.0.1"
+      }
+    },
+    "node_modules/release-it/node_modules/get-uri": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+      "integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "7.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/http-proxy-agent": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/https-proxy-agent": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/release-it/node_modules/mime-db": {
@@ -9600,10 +9705,74 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/release-it/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/release-it/node_modules/pac-proxy-agent": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4",
+        "get-uri": "7.0.0",
+        "http-proxy-agent": "8.0.0",
+        "https-proxy-agent": "8.0.0",
+        "pac-resolver": "8.0.0",
+        "quickjs-wasi": "^0.0.1",
+        "socks-proxy-agent": "9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/pac-resolver": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+      "integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "6.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^0.0.1"
+      }
+    },
+    "node_modules/release-it/node_modules/proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "8.0.0",
+        "https-proxy-agent": "8.0.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "8.0.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/release-it/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -9613,14 +9782,29 @@
         "node": ">=10"
       }
     },
-    "node_modules/release-it/node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+    "node_modules/release-it/node_modules/socks-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
       "engines": {
-        "node": ">=18.17"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/release-it/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/require-directory": {
@@ -9806,7 +9990,9 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "7.0.0",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9814,26 +10000,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/run-async": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -10224,6 +10390,8 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10233,11 +10401,15 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10246,7 +10418,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -10282,9 +10456,9 @@
       }
     },
     "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10903,6 +11077,8 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
@@ -10914,9 +11090,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11088,6 +11264,8 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11112,6 +11290,8 @@
     },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -11231,138 +11411,29 @@
       "license": "ISC"
     },
     "node_modules/windows-release": {
-      "version": "6.1.0",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+      "integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "execa": "^8.0.1"
+        "powershell-utils": "^0.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/windows-release/node_modules/execa": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/windows-release/node_modules/get-stream": {
-      "version": "8.0.1",
+    "node_modules/windows-release/node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/human-signals": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=16.17.0"
-      }
-    },
-    "node_modules/windows-release/node_modules/is-stream": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/onetime": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/path-key": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/windows-release/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11378,6 +11449,8 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -11491,14 +11564,17 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11695,19 +11771,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12298,11 +12361,13 @@
       "requires": {}
     },
     "@conventional-changelog/git-client": {
-      "version": "2.5.1",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
       "dev": true,
       "requires": {
         "@simple-libs/child-process-utils": "^1.0.0",
-        "@simple-libs/stream-utils": "^1.1.0",
+        "@simple-libs/stream-utils": "^1.2.0",
         "semver": "^7.5.2"
       },
       "dependencies": {
@@ -12436,12 +12501,12 @@
       "requires": {
         "@cap-js/cds-types": "^0.18.0",
         "@modelcontextprotocol/sdk": "^1.23.0",
-        "@release-it/conventional-changelog": "^10.0.1",
+        "@release-it/conventional-changelog": "^11.0.1",
         "@sap/xssec": "^4.13.3",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
-        "@types/node": "26.1.1",
+        "@types/node": "^26.1.1",
         "@types/sinon": "^17.0.4",
         "@types/supertest": "^6.0.2",
         "cors": "^2.8.5",
@@ -12454,7 +12519,7 @@
         "lint-staged": "^16.1.2",
         "markdown-link-check": "^3.14.1",
         "prettier": "^3.5.3",
-        "release-it": "^19.0.4",
+        "release-it": "^20.2.1",
         "sinon": "^21.0.0",
         "supertest": "^7.0.0",
         "ts-jest": "^29.4.0",
@@ -12767,11 +12832,13 @@
           "requires": {}
         },
         "@conventional-changelog/git-client": {
-          "version": "2.5.1",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+          "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
           "dev": true,
           "requires": {
             "@simple-libs/child-process-utils": "^1.0.0",
-            "@simple-libs/stream-utils": "^1.1.0",
+            "@simple-libs/stream-utils": "^1.2.0",
             "semver": "^7.5.2"
           },
           "dependencies": {
@@ -12933,219 +13000,179 @@
           "dev": true
         },
         "@inquirer/ansi": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-          "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+          "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
           "dev": true
         },
         "@inquirer/checkbox": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-          "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+          "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
           "dev": true,
           "requires": {
-            "@inquirer/ansi": "^1.0.2",
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/figures": "^1.0.15",
-            "@inquirer/type": "^3.0.10",
-            "yoctocolors-cjs": "^2.1.3"
+            "@inquirer/ansi": "^2.0.7",
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/figures": "^2.0.7",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/confirm": {
-          "version": "5.1.21",
-          "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-          "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+          "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/core": {
-          "version": "10.3.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-          "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+          "version": "11.2.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+          "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
           "dev": true,
           "requires": {
-            "@inquirer/ansi": "^1.0.2",
-            "@inquirer/figures": "^1.0.15",
-            "@inquirer/type": "^3.0.10",
+            "@inquirer/ansi": "^2.0.7",
+            "@inquirer/figures": "^2.0.7",
+            "@inquirer/type": "^4.0.7",
             "cli-width": "^4.1.0",
-            "mute-stream": "^2.0.0",
-            "signal-exit": "^4.1.0",
-            "wrap-ansi": "^6.2.0",
-            "yoctocolors-cjs": "^2.1.3"
+            "fast-wrap-ansi": "^0.2.0",
+            "mute-stream": "^3.0.0",
+            "signal-exit": "^4.1.0"
           },
           "dependencies": {
-            "emoji-regex": {
-              "version": "8.0.0",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-              "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-              "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-              "dev": true
-            },
             "signal-exit": {
               "version": "4.1.0",
               "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
               "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
               "dev": true
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-              "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "wrap-ansi": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-              "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-              }
             }
           }
         },
         "@inquirer/editor": {
-          "version": "4.2.23",
-          "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-          "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+          "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/external-editor": "^1.0.3",
-            "@inquirer/type": "^3.0.10"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/external-editor": "^3.0.3",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/expand": {
-          "version": "4.0.23",
-          "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-          "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+          "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10",
-            "yoctocolors-cjs": "^2.1.3"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/external-editor": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-          "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+          "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
           "dev": true,
           "requires": {
             "chardet": "^2.1.1",
-            "iconv-lite": "^0.7.0"
+            "iconv-lite": "^0.7.2"
           }
         },
         "@inquirer/figures": {
-          "version": "1.0.15",
-          "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-          "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+          "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
           "dev": true
         },
         "@inquirer/input": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-          "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+          "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/number": {
-          "version": "3.0.23",
-          "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-          "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+          "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/password": {
-          "version": "4.0.23",
-          "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-          "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+          "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
           "dev": true,
           "requires": {
-            "@inquirer/ansi": "^1.0.2",
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10"
+            "@inquirer/ansi": "^2.0.7",
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/prompts": {
-          "version": "7.10.1",
-          "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-          "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+          "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
           "dev": true,
           "requires": {
-            "@inquirer/checkbox": "^4.3.2",
-            "@inquirer/confirm": "^5.1.21",
-            "@inquirer/editor": "^4.2.23",
-            "@inquirer/expand": "^4.0.23",
-            "@inquirer/input": "^4.3.1",
-            "@inquirer/number": "^3.0.23",
-            "@inquirer/password": "^4.0.23",
-            "@inquirer/rawlist": "^4.1.11",
-            "@inquirer/search": "^3.2.2",
-            "@inquirer/select": "^4.4.2"
+            "@inquirer/checkbox": "^5.1.4",
+            "@inquirer/confirm": "^6.0.12",
+            "@inquirer/editor": "^5.1.1",
+            "@inquirer/expand": "^5.0.13",
+            "@inquirer/input": "^5.0.12",
+            "@inquirer/number": "^4.0.12",
+            "@inquirer/password": "^5.0.12",
+            "@inquirer/rawlist": "^5.2.8",
+            "@inquirer/search": "^4.1.8",
+            "@inquirer/select": "^5.1.4"
           }
         },
         "@inquirer/rawlist": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-          "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+          "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/type": "^3.0.10",
-            "yoctocolors-cjs": "^2.1.3"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/search": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-          "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+          "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
           "dev": true,
           "requires": {
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/figures": "^1.0.15",
-            "@inquirer/type": "^3.0.10",
-            "yoctocolors-cjs": "^2.1.3"
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/figures": "^2.0.7",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/select": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-          "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+          "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
           "dev": true,
           "requires": {
-            "@inquirer/ansi": "^1.0.2",
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/figures": "^1.0.15",
-            "@inquirer/type": "^3.0.10",
-            "yoctocolors-cjs": "^2.1.3"
+            "@inquirer/ansi": "^2.0.7",
+            "@inquirer/core": "^11.2.1",
+            "@inquirer/figures": "^2.0.7",
+            "@inquirer/type": "^4.0.7"
           }
         },
         "@inquirer/type": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-          "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+          "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
           "dev": true,
           "requires": {}
         },
@@ -13503,13 +13530,6 @@
           "version": "1.8.0",
           "dev": true
         },
-        "@nodeutils/defaults-deep": {
-          "version": "1.1.0",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.15.0"
-          }
-        },
         "@octokit/auth-token": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -13668,22 +13688,24 @@
           "dev": true
         },
         "@release-it/conventional-changelog": {
-          "version": "10.0.5",
-          "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-10.0.5.tgz",
-          "integrity": "sha512-Dxul3YlUsDLbIg+aR6T0QR/VyKwuJNR3GZM8mKVEwFO8GpH2H5vgnN7kacEvq/Qk5puDadOVbhbUq/KBjraemQ==",
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.1.tgz",
+          "integrity": "sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==",
           "dev": true,
           "requires": {
-            "@conventional-changelog/git-client": "^2.5.1",
+            "@conventional-changelog/git-client": "^2.7.0",
             "concat-stream": "^2.0.0",
-            "conventional-changelog": "^7.1.1",
-            "conventional-changelog-angular": "^8.1.0",
-            "conventional-changelog-conventionalcommits": "^9.1.0",
+            "conventional-changelog": "^7.2.0",
+            "conventional-changelog-angular": "^8.3.1",
+            "conventional-changelog-conventionalcommits": "^9.3.1",
             "conventional-recommended-bump": "^11.2.0",
-            "semver": "^7.7.3"
+            "semver": "^7.7.4"
           },
           "dependencies": {
             "semver": {
-              "version": "7.7.3",
+              "version": "7.8.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+              "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
               "dev": true
             }
           }
@@ -13749,25 +13771,17 @@
             }
           }
         },
+        "@simple-libs/hosted-git-info": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+          "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+          "dev": true
+        },
         "@simple-libs/stream-utils": {
-          "version": "1.1.0",
-          "dev": true,
-          "requires": {
-            "@types/node": "^22.0.0"
-          },
-          "dependencies": {
-            "@types/node": {
-              "version": "22.19.1",
-              "dev": true,
-              "requires": {
-                "undici-types": "~6.21.0"
-              }
-            },
-            "undici-types": {
-              "version": "6.21.0",
-              "dev": true
-            }
-          }
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+          "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+          "dev": true
         },
         "@sinclair/typebox": {
           "version": "0.27.8",
@@ -14100,6 +14114,8 @@
         },
         "@types/normalize-package-data": {
           "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+          "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
           "dev": true
         },
         "@types/parse-path": {
@@ -14326,6 +14342,8 @@
         },
         "array-ify": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+          "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
           "dev": true
         },
         "asap": {
@@ -14619,6 +14637,8 @@
         },
         "bundle-name": {
           "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+          "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
           "dev": true,
           "requires": {
             "run-applescript": "^7.0.0"
@@ -14723,9 +14743,9 @@
           "dev": true
         },
         "chardet": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-          "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+          "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
           "dev": true
         },
         "cheerio": {
@@ -14910,6 +14930,8 @@
         },
         "compare-func": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+          "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
           "dev": true,
           "requires": {
             "array-ify": "^1.0.0",
@@ -15034,28 +15056,35 @@
           "version": "1.0.5"
         },
         "conventional-changelog": {
-          "version": "7.1.1",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.1.tgz",
+          "integrity": "sha512-smcpqCeNRCAoL586/Iql8GfVsduP1JDrr7SAzKHWM5C5voDzKhc3QtqwVWeKMhvVw4iYfAr+znz1TF4kPXVm3A==",
           "dev": true,
           "requires": {
-            "@conventional-changelog/git-client": "^2.5.1",
+            "@conventional-changelog/git-client": "^2.7.0",
+            "@simple-libs/hosted-git-info": "^1.0.2",
             "@types/normalize-package-data": "^2.4.4",
             "conventional-changelog-preset-loader": "^5.0.0",
-            "conventional-changelog-writer": "^8.2.0",
-            "conventional-commits-parser": "^6.2.0",
+            "conventional-changelog-writer": "^8.4.0",
+            "conventional-commits-parser": "^6.4.0",
             "fd-package-json": "^2.0.0",
             "meow": "^13.0.0",
             "normalize-package-data": "^7.0.0"
           }
         },
         "conventional-changelog-angular": {
-          "version": "8.1.0",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+          "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
           "dev": true,
           "requires": {
             "compare-func": "^2.0.0"
           }
         },
         "conventional-changelog-conventionalcommits": {
-          "version": "9.1.0",
+          "version": "9.3.1",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+          "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
           "dev": true,
           "requires": {
             "compare-func": "^2.0.0"
@@ -15066,9 +15095,12 @@
           "dev": true
         },
         "conventional-changelog-writer": {
-          "version": "8.2.0",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+          "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
           "dev": true,
           "requires": {
+            "@simple-libs/stream-utils": "^1.2.0",
             "conventional-commits-filter": "^5.0.0",
             "handlebars": "^4.7.7",
             "meow": "^13.0.0",
@@ -15076,7 +15108,9 @@
           },
           "dependencies": {
             "semver": {
-              "version": "7.7.3",
+              "version": "7.8.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+              "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
               "dev": true
             }
           }
@@ -15086,9 +15120,12 @@
           "dev": true
         },
         "conventional-commits-parser": {
-          "version": "6.2.1",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+          "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
           "dev": true,
           "requires": {
+            "@simple-libs/stream-utils": "^1.2.0",
             "meow": "^13.0.0"
           }
         },
@@ -15232,7 +15269,9 @@
           "dev": true
         },
         "default-browser": {
-          "version": "5.2.1",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+          "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
           "dev": true,
           "requires": {
             "bundle-name": "^4.1.0",
@@ -15240,7 +15279,9 @@
           }
         },
         "default-browser-id": {
-          "version": "5.0.0",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+          "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
           "dev": true
         },
         "defer-to-connect": {
@@ -15249,12 +15290,14 @@
         },
         "define-lazy-prop": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
           "dev": true
         },
         "defu": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-          "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+          "version": "6.1.7",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+          "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
           "dev": true
         },
         "degenerator": {
@@ -16000,9 +16043,9 @@
           "dev": true
         },
         "eta": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
-          "integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+          "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
           "dev": true
         },
         "etag": {
@@ -16215,10 +16258,34 @@
           "version": "2.1.1",
           "dev": true
         },
+        "fast-string-truncated-width": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+          "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+          "dev": true
+        },
+        "fast-string-width": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+          "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+          "dev": true,
+          "requires": {
+            "fast-string-truncated-width": "^3.0.2"
+          }
+        },
         "fast-uri": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
           "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+        },
+        "fast-wrap-ansi": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+          "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+          "dev": true,
+          "requires": {
+            "fast-string-width": "^3.0.2"
+          }
         },
         "fb-watchman": {
           "version": "2.0.2",
@@ -16229,6 +16296,8 @@
         },
         "fd-package-json": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+          "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
           "dev": true,
           "requires": {
             "walk-up-path": "^4.0.0"
@@ -16577,7 +16646,9 @@
           "dev": true
         },
         "handlebars": {
-          "version": "4.7.8",
+          "version": "4.7.9",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+          "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5",
@@ -16634,6 +16705,8 @@
         },
         "hosted-git-info": {
           "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+          "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
           "dev": true,
           "requires": {
             "lru-cache": "^10.0.1"
@@ -16641,6 +16714,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "10.4.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+              "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
               "dev": true
             }
           }
@@ -16793,21 +16868,6 @@
           "version": "1.3.8",
           "dev": true
         },
-        "inquirer": {
-          "version": "12.11.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
-          "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
-          "dev": true,
-          "requires": {
-            "@inquirer/ansi": "^1.0.2",
-            "@inquirer/core": "^10.3.2",
-            "@inquirer/prompts": "^7.10.1",
-            "@inquirer/type": "^3.0.10",
-            "mute-stream": "^2.0.0",
-            "run-async": "^4.0.6",
-            "rxjs": "^7.8.2"
-          }
-        },
         "ip-address": {
           "version": "9.0.5",
           "dev": true,
@@ -16862,6 +16922,8 @@
         },
         "is-docker": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
           "dev": true
         },
         "is-extglob": {
@@ -16888,8 +16950,16 @@
             "is-extglob": "^2.1.1"
           }
         },
+        "is-in-ssh": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+          "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+          "dev": true
+        },
         "is-inside-container": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+          "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
           "dev": true,
           "requires": {
             "is-docker": "^3.0.0"
@@ -16957,7 +17027,9 @@
           "dev": true
         },
         "is-wsl": {
-          "version": "3.1.0",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+          "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
           "dev": true,
           "requires": {
             "is-inside-container": "^1.0.0"
@@ -17623,12 +17695,6 @@
             "p-locate": "^5.0.0"
           }
         },
-        "lodash": {
-          "version": "4.17.23",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-          "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-          "dev": true
-        },
         "lodash.capitalize": {
           "version": "4.2.1",
           "dev": true
@@ -17718,7 +17784,9 @@
           }
         },
         "macos-release": {
-          "version": "3.4.0",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+          "integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
           "dev": true
         },
         "make-dir": {
@@ -17871,9 +17939,9 @@
           "version": "2.0.0"
         },
         "mute-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-          "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+          "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
           "dev": true
         },
         "nano-spawn": {
@@ -17916,6 +17984,8 @@
         },
         "neo-async": {
           "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
           "dev": true
         },
         "nested-error-stacks": {
@@ -17993,6 +18063,8 @@
         },
         "normalize-package-data": {
           "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+          "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^8.0.0",
@@ -18001,7 +18073,9 @@
           },
           "dependencies": {
             "semver": {
-              "version": "7.7.3",
+              "version": "7.8.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+              "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
               "dev": true
             }
           }
@@ -18079,13 +18153,17 @@
           }
         },
         "open": {
-          "version": "10.2.0",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+          "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
           "dev": true,
           "requires": {
-            "default-browser": "^5.2.1",
+            "default-browser": "^5.4.0",
             "define-lazy-prop": "^3.0.0",
+            "is-in-ssh": "^1.0.0",
             "is-inside-container": "^1.0.0",
-            "wsl-utils": "^0.1.0"
+            "powershell-utils": "^0.1.0",
+            "wsl-utils": "^0.3.0"
           }
         },
         "opencollective-postinstall": {
@@ -18109,9 +18187,9 @@
           "dev": true
         },
         "ora": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-          "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+          "version": "9.3.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+          "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
           "dev": true,
           "requires": {
             "chalk": "^5.6.2",
@@ -18120,40 +18198,26 @@
             "is-interactive": "^2.0.0",
             "is-unicode-supported": "^2.1.0",
             "log-symbols": "^7.0.1",
-            "stdin-discarder": "^0.2.2",
-            "string-width": "^8.1.0",
-            "strip-ansi": "^7.1.2"
+            "stdin-discarder": "^0.3.1",
+            "string-width": "^8.1.0"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "6.2.2",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-              "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-              "dev": true
-            },
             "chalk": {
               "version": "5.6.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
               "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
               "dev": true
-            },
-            "strip-ansi": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-              "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^6.0.1"
-              }
             }
           }
         },
         "os-name": {
-          "version": "6.1.0",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+          "integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
           "dev": true,
           "requires": {
-            "macos-release": "^3.3.0",
-            "windows-release": "^6.1.0"
+            "macos-release": "^3.4.0",
+            "windows-release": "^7.1.0"
           }
         },
         "p-cancelable": {
@@ -18408,6 +18472,12 @@
             "pathe": "^2.0.3"
           }
         },
+        "powershell-utils": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+          "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+          "dev": true
+        },
         "prebuild-install": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -18548,6 +18618,12 @@
             "side-channel": "^1.1.0"
           }
         },
+        "quickjs-wasi": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+          "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+          "dev": true
+        },
         "range-parser": {
           "version": "1.2.1"
         },
@@ -18635,40 +18711,109 @@
           }
         },
         "release-it": {
-          "version": "19.2.4",
-          "resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
-          "integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+          "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
           "dev": true,
           "requires": {
-            "@nodeutils/defaults-deep": "1.1.0",
+            "@inquirer/prompts": "8.4.2",
             "@octokit/rest": "22.0.1",
             "@phun-ky/typeof": "2.0.3",
             "async-retry": "1.3.3",
             "c12": "3.3.3",
-            "ci-info": "^4.3.1",
-            "eta": "4.5.0",
+            "ci-info": "^4.4.0",
+            "defu": "^6.1.7",
+            "eta": "4.5.1",
             "git-url-parse": "16.1.0",
-            "inquirer": "12.11.1",
             "issue-parser": "7.0.1",
             "lodash.merge": "4.6.2",
             "mime-types": "3.0.2",
             "new-github-release-url": "2.0.0",
-            "open": "10.2.0",
-            "ora": "9.0.0",
-            "os-name": "6.1.0",
-            "proxy-agent": "6.5.0",
-            "semver": "7.7.3",
+            "open": "11.0.0",
+            "ora": "9.3.0",
+            "os-name": "7.0.0",
+            "proxy-agent": "7.0.0",
+            "semver": "7.7.4",
             "tinyglobby": "0.2.15",
-            "undici": "6.23.0",
+            "undici": "7.28.0",
             "url-join": "5.0.0",
             "wildcard-match": "5.1.4",
-            "yargs-parser": "21.1.1"
+            "yargs-parser": "22.0.0"
           },
           "dependencies": {
+            "agent-base": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+              "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+              "dev": true
+            },
             "ci-info": {
-              "version": "4.3.1",
-              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-              "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+              "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+              "dev": true
+            },
+            "data-uri-to-buffer": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+              "integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
+              "dev": true
+            },
+            "debug": {
+              "version": "4.4.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+              "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.3"
+              }
+            },
+            "degenerator": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+              "integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+              "dev": true,
+              "requires": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+              }
+            },
+            "get-uri": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+              "integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+              "dev": true,
+              "requires": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "7.0.0",
+                "debug": "^4.3.4"
+              }
+            },
+            "http-proxy-agent": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+              "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+              "dev": true,
+              "requires": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4"
+              }
+            },
+            "https-proxy-agent": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+              "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+              "dev": true,
+              "requires": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4"
+              }
+            },
+            "lru-cache": {
+              "version": "7.18.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+              "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
               "dev": true
             },
             "mime-db": {
@@ -18686,16 +18831,75 @@
                 "mime-db": "^1.54.0"
               }
             },
-            "semver": {
-              "version": "7.7.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-              "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
               "dev": true
             },
-            "undici": {
-              "version": "6.23.0",
-              "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-              "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+            "pac-proxy-agent": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+              "integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
+              "dev": true,
+              "requires": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "get-uri": "7.0.0",
+                "http-proxy-agent": "8.0.0",
+                "https-proxy-agent": "8.0.0",
+                "pac-resolver": "8.0.0",
+                "quickjs-wasi": "^0.0.1",
+                "socks-proxy-agent": "9.0.0"
+              }
+            },
+            "pac-resolver": {
+              "version": "8.0.0",
+              "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+              "integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
+              "dev": true,
+              "requires": {
+                "degenerator": "6.0.0",
+                "netmask": "^2.0.2"
+              }
+            },
+            "proxy-agent": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+              "integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
+              "dev": true,
+              "requires": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "8.0.0",
+                "https-proxy-agent": "8.0.0",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "8.0.0",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "9.0.0"
+              }
+            },
+            "semver": {
+              "version": "7.7.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+              "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+              "dev": true
+            },
+            "socks-proxy-agent": {
+              "version": "9.0.0",
+              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+              "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+              "dev": true,
+              "requires": {
+                "agent-base": "8.0.0",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+              }
+            },
+            "yargs-parser": {
+              "version": "22.0.0",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+              "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
               "dev": true
             }
           }
@@ -18810,23 +19014,10 @@
           }
         },
         "run-applescript": {
-          "version": "7.0.0",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+          "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
           "dev": true
-        },
-        "run-async": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-          "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "7.8.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-          "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
         },
         "safe-buffer": {
           "version": "5.2.1"
@@ -19061,6 +19252,8 @@
         },
         "spdx-correct": {
           "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+          "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -19069,10 +19262,14 @@
         },
         "spdx-exceptions": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+          "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -19080,7 +19277,9 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.22",
+          "version": "3.0.23",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+          "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
           "dev": true
         },
         "sprintf-js": {
@@ -19104,9 +19303,9 @@
           "version": "2.0.1"
         },
         "stdin-discarder": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-          "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+          "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
           "dev": true
         },
         "string_decoder": {
@@ -19452,13 +19651,15 @@
         },
         "uglify-js": {
           "version": "3.19.3",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+          "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
           "dev": true,
           "optional": true
         },
         "undici": {
-          "version": "7.19.1",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-          "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+          "version": "7.28.0",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+          "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
           "dev": true
         },
         "undici-types": {
@@ -19564,6 +19765,8 @@
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -19579,6 +19782,8 @@
         },
         "walk-up-path": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+          "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
           "dev": true
         },
         "walker": {
@@ -19661,67 +19866,18 @@
           "dev": true
         },
         "windows-release": {
-          "version": "6.1.0",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+          "integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
           "dev": true,
           "requires": {
-            "execa": "^8.0.1"
+            "powershell-utils": "^0.2.0"
           },
           "dependencies": {
-            "execa": {
-              "version": "8.0.1",
-              "dev": true,
-              "requires": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
-              }
-            },
-            "get-stream": {
-              "version": "8.0.1",
-              "dev": true
-            },
-            "human-signals": {
-              "version": "5.0.0",
-              "dev": true
-            },
-            "is-stream": {
-              "version": "3.0.0",
-              "dev": true
-            },
-            "mimic-fn": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "npm-run-path": {
-              "version": "5.3.0",
-              "dev": true,
-              "requires": {
-                "path-key": "^4.0.0"
-              }
-            },
-            "onetime": {
-              "version": "6.0.0",
-              "dev": true,
-              "requires": {
-                "mimic-fn": "^4.0.0"
-              }
-            },
-            "path-key": {
-              "version": "4.0.0",
-              "dev": true
-            },
-            "signal-exit": {
-              "version": "4.1.0",
-              "dev": true
-            },
-            "strip-final-newline": {
-              "version": "3.0.0",
+            "powershell-utils": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+              "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
               "dev": true
             }
           }
@@ -19732,6 +19888,8 @@
         },
         "wordwrap": {
           "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
           "dev": true
         },
         "wrap-ansi": {
@@ -19796,10 +19954,13 @@
           "requires": {}
         },
         "wsl-utils": {
-          "version": "0.1.0",
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+          "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
           "dev": true,
           "requires": {
-            "is-wsl": "^3.1.0"
+            "is-wsl": "^3.1.0",
+            "powershell-utils": "^0.1.0"
           }
         },
         "xdg-basedir": {
@@ -19924,12 +20085,6 @@
           "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
           "dev": true
         },
-        "yoctocolors-cjs": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-          "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
-          "dev": true
-        },
         "zod": {
           "version": "3.25.67"
         },
@@ -19974,219 +20129,179 @@
       "dev": true
     },
     "@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
       "dev": true
     },
     "@inquirer/checkbox": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
-      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
       "dev": true,
       "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
       "dev": true,
       "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "dependencies": {
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
           "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
         }
       }
     },
     "@inquirer/editor": {
-      "version": "4.2.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
-      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/external-editor": "^1.0.3",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/expand": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
-      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/external-editor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
-      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
       "dev": true,
       "requires": {
         "chardet": "^2.1.1",
-        "iconv-lite": "^0.7.0"
+        "iconv-lite": "^0.7.2"
       }
     },
     "@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
       "dev": true
     },
     "@inquirer/input": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
-      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/number": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
-      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/password": {
-      "version": "4.0.23",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
-      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
       "dev": true,
       "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/prompts": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
-      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+      "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
       "dev": true,
       "requires": {
-        "@inquirer/checkbox": "^4.3.2",
-        "@inquirer/confirm": "^5.1.21",
-        "@inquirer/editor": "^4.2.23",
-        "@inquirer/expand": "^4.0.23",
-        "@inquirer/input": "^4.3.1",
-        "@inquirer/number": "^3.0.23",
-        "@inquirer/password": "^4.0.23",
-        "@inquirer/rawlist": "^4.1.11",
-        "@inquirer/search": "^3.2.2",
-        "@inquirer/select": "^4.4.2"
+        "@inquirer/checkbox": "^5.1.4",
+        "@inquirer/confirm": "^6.0.12",
+        "@inquirer/editor": "^5.1.1",
+        "@inquirer/expand": "^5.0.13",
+        "@inquirer/input": "^5.0.12",
+        "@inquirer/number": "^4.0.12",
+        "@inquirer/password": "^5.0.12",
+        "@inquirer/rawlist": "^5.2.8",
+        "@inquirer/search": "^4.1.8",
+        "@inquirer/select": "^5.1.4"
       }
     },
     "@inquirer/rawlist": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
-      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/search": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
-      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
       "dev": true,
       "requires": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/select": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
-      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
       "dev": true,
       "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
-        "yoctocolors-cjs": "^2.1.3"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       }
     },
     "@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
       "dev": true,
       "requires": {}
     },
@@ -20544,13 +20659,6 @@
       "version": "1.8.0",
       "dev": true
     },
-    "@nodeutils/defaults-deep": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.15.0"
-      }
-    },
     "@octokit/auth-token": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
@@ -20709,22 +20817,24 @@
       "dev": true
     },
     "@release-it/conventional-changelog": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-10.0.5.tgz",
-      "integrity": "sha512-Dxul3YlUsDLbIg+aR6T0QR/VyKwuJNR3GZM8mKVEwFO8GpH2H5vgnN7kacEvq/Qk5puDadOVbhbUq/KBjraemQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.1.tgz",
+      "integrity": "sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==",
       "dev": true,
       "requires": {
-        "@conventional-changelog/git-client": "^2.5.1",
+        "@conventional-changelog/git-client": "^2.7.0",
         "concat-stream": "^2.0.0",
-        "conventional-changelog": "^7.1.1",
-        "conventional-changelog-angular": "^8.1.0",
-        "conventional-changelog-conventionalcommits": "^9.1.0",
+        "conventional-changelog": "^7.2.0",
+        "conventional-changelog-angular": "^8.3.1",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "conventional-recommended-bump": "^11.2.0",
-        "semver": "^7.7.3"
+        "semver": "^7.7.4"
       },
       "dependencies": {
         "semver": {
-          "version": "7.7.3",
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         }
       }
@@ -20790,25 +20900,17 @@
         }
       }
     },
+    "@simple-libs/hosted-git-info": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/hosted-git-info/-/hosted-git-info-1.0.2.tgz",
+      "integrity": "sha512-aAmGQdMH+ZinytKuA2832u0ATeOFNYNk4meBEXtB5xaPotUgggYNhq5tYU/v17wEbmTW5P9iHNqNrFyrhnqBAg==",
+      "dev": true
+    },
     "@simple-libs/stream-utils": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "@types/node": "^22.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "22.19.1",
-          "dev": true,
-          "requires": {
-            "undici-types": "~6.21.0"
-          }
-        },
-        "undici-types": {
-          "version": "6.21.0",
-          "dev": true
-        }
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -21141,6 +21243,8 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
     "@types/parse-path": {
@@ -21367,6 +21471,8 @@
     },
     "array-ify": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
     },
     "asap": {
@@ -21660,6 +21766,8 @@
     },
     "bundle-name": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dev": true,
       "requires": {
         "run-applescript": "^7.0.0"
@@ -21764,9 +21872,9 @@
       "dev": true
     },
     "chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "dev": true
     },
     "cheerio": {
@@ -21951,6 +22059,8 @@
     },
     "compare-func": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
       "dev": true,
       "requires": {
         "array-ify": "^1.0.0",
@@ -22075,28 +22185,35 @@
       "version": "1.0.5"
     },
     "conventional-changelog": {
-      "version": "7.1.1",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.2.1.tgz",
+      "integrity": "sha512-smcpqCeNRCAoL586/Iql8GfVsduP1JDrr7SAzKHWM5C5voDzKhc3QtqwVWeKMhvVw4iYfAr+znz1TF4kPXVm3A==",
       "dev": true,
       "requires": {
-        "@conventional-changelog/git-client": "^2.5.1",
+        "@conventional-changelog/git-client": "^2.7.0",
+        "@simple-libs/hosted-git-info": "^1.0.2",
         "@types/normalize-package-data": "^2.4.4",
         "conventional-changelog-preset-loader": "^5.0.0",
-        "conventional-changelog-writer": "^8.2.0",
-        "conventional-commits-parser": "^6.2.0",
+        "conventional-changelog-writer": "^8.4.0",
+        "conventional-commits-parser": "^6.4.0",
         "fd-package-json": "^2.0.0",
         "meow": "^13.0.0",
         "normalize-package-data": "^7.0.0"
       }
     },
     "conventional-changelog-angular": {
-      "version": "8.1.0",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "9.1.0",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"
@@ -22107,9 +22224,12 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "8.2.0",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.4.0.tgz",
+      "integrity": "sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==",
       "dev": true,
       "requires": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
         "meow": "^13.0.0",
@@ -22117,7 +22237,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.7.3",
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         }
       }
@@ -22127,9 +22249,12 @@
       "dev": true
     },
     "conventional-commits-parser": {
-      "version": "6.2.1",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "dev": true,
       "requires": {
+        "@simple-libs/stream-utils": "^1.2.0",
         "meow": "^13.0.0"
       }
     },
@@ -22273,7 +22398,9 @@
       "dev": true
     },
     "default-browser": {
-      "version": "5.2.1",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "requires": {
         "bundle-name": "^4.1.0",
@@ -22281,7 +22408,9 @@
       }
     },
     "default-browser-id": {
-      "version": "5.0.0",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true
     },
     "defer-to-connect": {
@@ -22290,12 +22419,14 @@
     },
     "define-lazy-prop": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true
     },
     "defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true
     },
     "degenerator": {
@@ -23041,9 +23172,9 @@
       "dev": true
     },
     "eta": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.0.tgz",
-      "integrity": "sha512-qifAYjuW5AM1eEEIsFnOwB+TGqu6ynU3OKj9WbUTOtUBHFPZqL03XUW34kbp3zm19Ald+U8dEyRXaVsUck+Y1g==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+      "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
       "dev": true
     },
     "etag": {
@@ -23256,10 +23387,34 @@
       "version": "2.1.1",
       "dev": true
     },
+    "fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true
+    },
+    "fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "requires": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
+    },
+    "fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "requires": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "fb-watchman": {
       "version": "2.0.2",
@@ -23270,6 +23425,8 @@
     },
     "fd-package-json": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
       "dev": true,
       "requires": {
         "walk-up-path": "^4.0.0"
@@ -23618,7 +23775,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.8",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -23675,6 +23834,8 @@
     },
     "hosted-git-info": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
       "dev": true,
       "requires": {
         "lru-cache": "^10.0.1"
@@ -23682,6 +23843,8 @@
       "dependencies": {
         "lru-cache": {
           "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
           "dev": true
         }
       }
@@ -23834,21 +23997,6 @@
       "version": "1.3.8",
       "dev": true
     },
-    "inquirer": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
-      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
-      "dev": true,
-      "requires": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/prompts": "^7.10.1",
-        "@inquirer/type": "^3.0.10",
-        "mute-stream": "^2.0.0",
-        "run-async": "^4.0.6",
-        "rxjs": "^7.8.2"
-      }
-    },
     "ip-address": {
       "version": "9.0.5",
       "dev": true,
@@ -23903,6 +24051,8 @@
     },
     "is-docker": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true
     },
     "is-extglob": {
@@ -23929,8 +24079,16 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true
+    },
     "is-inside-container": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
       "requires": {
         "is-docker": "^3.0.0"
@@ -23998,7 +24156,9 @@
       "dev": true
     },
     "is-wsl": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "requires": {
         "is-inside-container": "^1.0.0"
@@ -24664,12 +24824,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true
-    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "dev": true
@@ -24759,7 +24913,9 @@
       }
     },
     "macos-release": {
-      "version": "3.4.0",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+      "integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
       "dev": true
     },
     "make-dir": {
@@ -24912,9 +25068,9 @@
       "version": "2.0.0"
     },
     "mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
       "dev": true
     },
     "nano-spawn": {
@@ -24957,6 +25113,8 @@
     },
     "neo-async": {
       "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -25034,6 +25192,8 @@
     },
     "normalize-package-data": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^8.0.0",
@@ -25042,7 +25202,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.7.3",
+          "version": "7.8.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+          "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
           "dev": true
         }
       }
@@ -25120,13 +25282,17 @@
       }
     },
     "open": {
-      "version": "10.2.0",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "requires": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       }
     },
     "opencollective-postinstall": {
@@ -25150,9 +25316,9 @@
       "dev": true
     },
     "ora": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
-      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
       "dev": true,
       "requires": {
         "chalk": "^5.6.2",
@@ -25161,40 +25327,26 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^8.1.0",
-        "strip-ansi": "^7.1.2"
+        "stdin-discarder": "^0.3.1",
+        "string-width": "^8.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-          "dev": true
-        },
         "chalk": {
           "version": "5.6.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
           "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
         }
       }
     },
     "os-name": {
-      "version": "6.1.0",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+      "integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
       "dev": true,
       "requires": {
-        "macos-release": "^3.3.0",
-        "windows-release": "^6.1.0"
+        "macos-release": "^3.4.0",
+        "windows-release": "^7.1.0"
       }
     },
     "p-cancelable": {
@@ -25449,6 +25601,12 @@
         "pathe": "^2.0.3"
       }
     },
+    "powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true
+    },
     "prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -25589,6 +25747,12 @@
         "side-channel": "^1.1.0"
       }
     },
+    "quickjs-wasi": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+      "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+      "dev": true
+    },
     "range-parser": {
       "version": "1.2.1"
     },
@@ -25676,40 +25840,109 @@
       }
     },
     "release-it": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-19.2.4.tgz",
-      "integrity": "sha512-BwaJwQYUIIAKuDYvpqQTSoy0U7zIy6cHyEjih/aNaFICphGahia4cjDANuFXb7gVZ51hIK9W0io6fjNQWXqICg==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
+      "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
       "dev": true,
       "requires": {
-        "@nodeutils/defaults-deep": "1.1.0",
+        "@inquirer/prompts": "8.4.2",
         "@octokit/rest": "22.0.1",
         "@phun-ky/typeof": "2.0.3",
         "async-retry": "1.3.3",
         "c12": "3.3.3",
-        "ci-info": "^4.3.1",
-        "eta": "4.5.0",
+        "ci-info": "^4.4.0",
+        "defu": "^6.1.7",
+        "eta": "4.5.1",
         "git-url-parse": "16.1.0",
-        "inquirer": "12.11.1",
         "issue-parser": "7.0.1",
         "lodash.merge": "4.6.2",
         "mime-types": "3.0.2",
         "new-github-release-url": "2.0.0",
-        "open": "10.2.0",
-        "ora": "9.0.0",
-        "os-name": "6.1.0",
-        "proxy-agent": "6.5.0",
-        "semver": "7.7.3",
+        "open": "11.0.0",
+        "ora": "9.3.0",
+        "os-name": "7.0.0",
+        "proxy-agent": "7.0.0",
+        "semver": "7.7.4",
         "tinyglobby": "0.2.15",
-        "undici": "6.23.0",
+        "undici": "7.28.0",
         "url-join": "5.0.0",
         "wildcard-match": "5.1.4",
-        "yargs-parser": "21.1.1"
+        "yargs-parser": "22.0.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+          "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+          "dev": true
+        },
         "ci-info": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-          "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+          "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+          "dev": true
+        },
+        "data-uri-to-buffer": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+          "integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "degenerator": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+          "integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+          "dev": true,
+          "requires": {
+            "ast-types": "^0.13.4",
+            "escodegen": "^2.1.0",
+            "esprima": "^4.0.1"
+          }
+        },
+        "get-uri": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+          "integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+          "dev": true,
+          "requires": {
+            "basic-ftp": "^5.0.2",
+            "data-uri-to-buffer": "7.0.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+          "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+          "dev": true,
+          "requires": {
+            "agent-base": "8.0.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+          "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+          "dev": true,
+          "requires": {
+            "agent-base": "8.0.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
           "dev": true
         },
         "mime-db": {
@@ -25727,16 +25960,75 @@
             "mime-db": "^1.54.0"
           }
         },
-        "semver": {
-          "version": "7.7.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-          "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
-        "undici": {
-          "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-          "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+        "pac-proxy-agent": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+          "integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "8.0.0",
+            "debug": "^4.3.4",
+            "get-uri": "7.0.0",
+            "http-proxy-agent": "8.0.0",
+            "https-proxy-agent": "8.0.0",
+            "pac-resolver": "8.0.0",
+            "quickjs-wasi": "^0.0.1",
+            "socks-proxy-agent": "9.0.0"
+          }
+        },
+        "pac-resolver": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+          "integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
+          "dev": true,
+          "requires": {
+            "degenerator": "6.0.0",
+            "netmask": "^2.0.2"
+          }
+        },
+        "proxy-agent": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
+          "dev": true,
+          "requires": {
+            "agent-base": "8.0.0",
+            "debug": "^4.3.4",
+            "http-proxy-agent": "8.0.0",
+            "https-proxy-agent": "8.0.0",
+            "lru-cache": "^7.14.1",
+            "pac-proxy-agent": "8.0.0",
+            "proxy-from-env": "^1.1.0",
+            "socks-proxy-agent": "9.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+          "dev": true
+        },
+        "socks-proxy-agent": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+          "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+          "dev": true,
+          "requires": {
+            "agent-base": "8.0.0",
+            "debug": "^4.3.4",
+            "socks": "^2.8.3"
+          }
+        },
+        "yargs-parser": {
+          "version": "22.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+          "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
           "dev": true
         }
       }
@@ -25851,23 +26143,10 @@
       }
     },
     "run-applescript": {
-      "version": "7.0.0",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true
-    },
-    "run-async": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
-      "dev": true
-    },
-    "rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.1.0"
-      }
     },
     "safe-buffer": {
       "version": "5.2.1"
@@ -26102,6 +26381,8 @@
     },
     "spdx-correct": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -26110,10 +26391,14 @@
     },
     "spdx-exceptions": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -26121,7 +26406,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true
     },
     "sprintf-js": {
@@ -26145,9 +26432,9 @@
       "version": "2.0.1"
     },
     "stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "dev": true
     },
     "string_decoder": {
@@ -26493,13 +26780,15 @@
     },
     "uglify-js": {
       "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true
     },
     "undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true
     },
     "undici-types": {
@@ -26605,6 +26894,8 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -26620,6 +26911,8 @@
     },
     "walk-up-path": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
       "dev": true
     },
     "walker": {
@@ -26702,67 +26995,18 @@
       "dev": true
     },
     "windows-release": {
-      "version": "6.1.0",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+      "integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
       "dev": true,
       "requires": {
-        "execa": "^8.0.1"
+        "powershell-utils": "^0.2.0"
       },
       "dependencies": {
-        "execa": {
-          "version": "8.0.1",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
-            "is-stream": "^3.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^5.1.0",
-            "onetime": "^6.0.0",
-            "signal-exit": "^4.1.0",
-            "strip-final-newline": "^3.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "8.0.1",
-          "dev": true
-        },
-        "human-signals": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "mimic-fn": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "5.3.0",
-          "dev": true,
-          "requires": {
-            "path-key": "^4.0.0"
-          }
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "path-key": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "dev": true
-        },
-        "strip-final-newline": {
-          "version": "3.0.0",
+        "powershell-utils": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+          "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
           "dev": true
         }
       }
@@ -26773,6 +27017,8 @@
     },
     "wordwrap": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wrap-ansi": {
@@ -26837,10 +27083,13 @@
       "requires": {}
     },
     "wsl-utils": {
-      "version": "0.1.0",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "dev": true,
       "requires": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       }
     },
     "xdg-basedir": {
@@ -26963,12 +27212,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
       "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true
-    },
-    "yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "dev": true
     },
     "zod": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@cap-js/cds-types": "^0.18.0",
-    "@release-it/conventional-changelog": "^10.0.1",
+    "@release-it/conventional-changelog": "^11.0.1",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
@@ -70,7 +70,7 @@
     "lint-staged": "^16.1.2",
     "markdown-link-check": "^3.14.1",
     "prettier": "^3.5.3",
-    "release-it": "^19.0.4",
+    "release-it": "^20.2.1",
     "sinon": "^21.0.0",
     "supertest": "^7.0.0",
     "ts-jest": "^29.4.0",


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->
Upgrade the CI dependency `release-it` to prevent release pipeline from failing

## Type of Change

<!-- Mark the relevant option with an "x" -->
- [ ] 🚀 **Feature** - New functionality or enhancement
- [X] 🐛 **Bug Fix** - Non-breaking change that fixes an issue
- [ ] 🚨 **Hotfix** - Critical fix for production issue
- [ ] 🔧 **Chore** - Maintenance, refactoring, or tooling changes
- [ ] 📚 **Documentation** - Documentation updates only
- [ ] ⚡ **Performance** - Performance improvements
- [ ] 🎨 **Style** - Code style/formatting changes

## What Changed

<!-- List the main changes made -->
- `release-it` package upgraded
- `@release-it/conventional-changelog` upgraded


---

